### PR TITLE
GCLOUD2-10257: gcorelabscloud-go version update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/G-Core/gcore-dns-sdk-go v0.2.3
 	github.com/G-Core/gcore-storage-sdk-go v0.1.34
 	github.com/G-Core/gcorelabscdn-go v0.1.29
-	github.com/G-Core/gcorelabscloud-go v0.5.31
+	github.com/G-Core/gcorelabscloud-go v0.5.39
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/G-Core/gcore-storage-sdk-go v0.1.34 h1:0GPQfz1kA6mQi6fiisGsh0Um4H9PZe
 github.com/G-Core/gcore-storage-sdk-go v0.1.34/go.mod h1:BUAEZZZJJt/+luRFunqziv3+JnbVMLbQXDWz9kV8Te8=
 github.com/G-Core/gcorelabscdn-go v0.1.29 h1:Nob071Zec1i2n7W3eXzlQfF6AT7ixwkf36FDZ22AoLo=
 github.com/G-Core/gcorelabscdn-go v0.1.29/go.mod h1:iSGXaTvZBzDHQW+rKFS918BgFVpONcyLEijwh8WsXpE=
-github.com/G-Core/gcorelabscloud-go v0.5.31 h1:cbGJVaBf4zUK/CXM8rKEGhfl68sq4QJpGwEwmAM4tV4=
-github.com/G-Core/gcorelabscloud-go v0.5.31/go.mod h1:tizV2NaASUpPI6NfJVIOM5yBI8MOriAzSHA/5K1m6aU=
+github.com/G-Core/gcorelabscloud-go v0.5.39 h1:Uikb0tHho+IJ5w8CL1F6Jw9ChzsvgC6zoJe0PqPVmtY=
+github.com/G-Core/gcorelabscloud-go v0.5.39/go.mod h1:tizV2NaASUpPI6NfJVIOM5yBI8MOriAzSHA/5K1m6aU=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=


### PR DESCRIPTION
* To support IPv6 protocols we need to update gcorelabscloud-go lib