### PR TITLE
CDN-6169 cdn rules import fix

### DIFF
--- a/docs/resources/cdn_resource.md
+++ b/docs/resources/cdn_resource.md
@@ -17,6 +17,14 @@ provider gcore {
   permanent_api_token = "251$d3361.............1b35f26d8"
 }
 
+resource "gcore_cdn_origingroup" "origin_group_1" {
+  name     = "origin_group_1"
+  use_next = true
+  origin {
+    source  = "example.com"
+    enabled = true
+  }
+}
 
 resource "gcore_cdn_resource" "cdn_example_com" {
   cname               = "cdn.example.com"

--- a/examples/resources/gcore_cdn_resource/resource.tf
+++ b/examples/resources/gcore_cdn_resource/resource.tf
@@ -2,6 +2,14 @@ provider gcore {
   permanent_api_token = "251$d3361.............1b35f26d8"
 }
 
+resource "gcore_cdn_origingroup" "origin_group_1" {
+  name     = "origin_group_1"
+  use_next = true
+  origin {
+    source  = "example.com"
+    enabled = true
+  }
+}
 
 resource "gcore_cdn_resource" "cdn_example_com" {
   cname               = "cdn.example.com"

--- a/gcore/resource_gcore_cdn_rule_test.go
+++ b/gcore/resource_gcore_cdn_rule_test.go
@@ -72,6 +72,11 @@ resource "gcore_cdn_rule" "acctest" {
 					resource.TestCheckResourceAttr(fullName, "options.0.host_header.0.value", "rule-host.com"),
 				),
 			},
+			{
+				ResourceName:      "gcore_cdn_rule.acctest",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
fix importing the CDN rule resources, update cdn docs by tfplugindocs

rules can be imported using `<resource_id>:<rule_id>` as `ADDR ID` param