### PR TITLE
MKAAS-1131 Prevent reordering cluster pools on read

### DIFF
--- a/gcore/data_source_gcore_region_test.go
+++ b/gcore/data_source_gcore_region_test.go
@@ -23,7 +23,7 @@ func TestAccRegionDataSource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rs, err := regions.ListAll(client)
+	rs, err := regions.ListAll(client, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gcore/resource_gcore_k8sv2_test.go
+++ b/gcore/resource_gcore_k8sv2_test.go
@@ -80,7 +80,7 @@ func TestAccK8sV2(t *testing.T) {
 	}
 
 	kpOpts := keypairs.CreateOpts{
-		Name:      kpName,
+		Name:      "testkp",
 		PublicKey: pkTest,
 		ProjectID: pid,
 	}
@@ -115,7 +115,7 @@ func TestAccK8sV2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccK8sDestroy,
+		CheckDestroy:      testAccK8sV2Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: ipTemplate,


### PR DESCRIPTION
Cluster pools are always returned from the backend in alphabetical order. This change attempts to match returned pools to the ones in Terraform state file to prevent their reordering.

I also fixed tests, which broke after k8s v1 resource removal.

Closes #66 