### PR TITLE
chore: better example for image data source

### DIFF
--- a/examples/data-sources/gcore_image/data-source.tf
+++ b/examples/data-sources/gcore_image/data-source.tf
@@ -11,7 +11,7 @@ data "gcore_region" "rg" {
 }
 
 data "gcore_image" "ubuntu" {
-  name       = "ubuntu-20.04-x64"
+  name       = "ubuntu-22.04-x64"
   region_id  = data.gcore_region.rg.id
   project_id = data.gcore_project.pr.id
 }

--- a/examples/data-sources/gcore_image/data-source.tf
+++ b/examples/data-sources/gcore_image/data-source.tf
@@ -11,7 +11,7 @@ data "gcore_region" "rg" {
 }
 
 data "gcore_image" "ubuntu" {
-  name       = "ubuntu-20.04"
+  name       = "ubuntu-20.04-x64"
   region_id  = data.gcore_region.rg.id
   project_id = data.gcore_project.pr.id
 }


### PR DESCRIPTION
Using `ubuntu-20.04` is uncertain because in some regions, such as Baku and Mumbai, the arm64 image ID is returned, while in others, it returns the x64 image.