### PR TITLE
update to a new cdn library version; CDP-617

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlekSi/pointer v1.2.0
 	github.com/G-Core/gcore-dns-sdk-go v0.2.7-0.20230801110428-99ef24b50d4d
 	github.com/G-Core/gcore-storage-sdk-go v0.1.34
-	github.com/G-Core/gcorelabscdn-go v1.0.9
+	github.com/G-Core/gcorelabscdn-go v1.0.10
 	github.com/G-Core/gcorelabscloud-go v0.7.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/G-Core/gcorelabscdn-go v1.0.8 h1:1qYPz0SwS4uMw7KQhKpLpXKIRAS1DfSDYvDk
 github.com/G-Core/gcorelabscdn-go v1.0.8/go.mod h1:iSGXaTvZBzDHQW+rKFS918BgFVpONcyLEijwh8WsXpE=
 github.com/G-Core/gcorelabscdn-go v1.0.9 h1:diEHzf94AiBpgK1onC8cv8NS/Jklu34ZlMnlwTrjJpU=
 github.com/G-Core/gcorelabscdn-go v1.0.9/go.mod h1:iSGXaTvZBzDHQW+rKFS918BgFVpONcyLEijwh8WsXpE=
+github.com/G-Core/gcorelabscdn-go v1.0.10 h1:0iLUn0uhckXilJKeDgPtrUOhPw2eptGE1Vzi8koMdiM=
+github.com/G-Core/gcorelabscdn-go v1.0.10/go.mod h1:iSGXaTvZBzDHQW+rKFS918BgFVpONcyLEijwh8WsXpE=
 github.com/G-Core/gcorelabscloud-go v0.7.0 h1:qWiz6pHvBHgMrNvG7NQf7K6xKe9eAeDLxLI5/OWyXLM=
 github.com/G-Core/gcorelabscloud-go v0.7.0/go.mod h1:13Z1USxlxPbDFuYQyWqfNexlk4kUvOYTXbnvV/Z1lZo=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=


### PR DESCRIPTION
CDN library changelog

## What's Changed
* fix origin groups scheme: using a proper use_next field in json by @freenoth in https://github.com/G-Core/gcorelabscdn-go/pull/52
* CDP-617 support 2-step deletion for rules and resources by @freenoth in https://github.com/G-Core/gcorelabscdn-go/pull/53

**Full Changelog**: https://github.com/G-Core/gcorelabscdn-go/compare/v1.0.9...v1.0.10