### PR TITLE
add more allowed record filter

### DIFF
--- a/docs/resources/dns_zone_record.md
+++ b/docs/resources/dns_zone_record.md
@@ -67,7 +67,7 @@ resource "gcore_dns_zone_record" "subdomain_examplezone" {
       latlong    = [52.367, 4.9041]
       asn        = [12345]
       ip         = ["1.1.1.1"]
-      notes      = ["notes"]
+      notes      = "notes"
       continents = ["asia"]
       countries  = ["russia"]
       default    = true
@@ -79,7 +79,7 @@ resource "gcore_dns_zone_record" "subdomain_examplezone_mx" {
   zone   = "examplezone.com"
   domain = "subdomain.examplezone.com"
   type   = "MX"
-  ttl    = 10
+  ttl    = 120
 
   resource_record {
     content = "10 mail.my.com."
@@ -91,7 +91,7 @@ resource "gcore_dns_zone_record" "subdomain_examplezone_caa" {
   zone   = "examplezone.com"
   domain = "subdomain.examplezone.com"
   type   = "CAA"
-  ttl    = 10
+  ttl    = 120
 
   resource_record {
     content = "0 issue \"company.org; account=12345\""

--- a/examples/resources/gcore_dns_zone_record/resource.tf
+++ b/examples/resources/gcore_dns_zone_record/resource.tf
@@ -18,7 +18,7 @@ resource "gcore_dns_zone_record" "example_rrset0" {
   zone   = gcore_dns_zone.examplezone0.name
   domain = "${gcore_dns_zone.examplezone0.name}"
   type   = "A"
-  ttl    = 100
+  ttl    = 120
 
   resource_record {
     content = "127.0.0.100"
@@ -36,7 +36,7 @@ resource "gcore_dns_zone_record" "subdomain_examplezone" {
   zone   = "examplezone.com"
   domain = "subdomain.examplezone.com"
   type   = "TXT"
-  ttl    = 10
+  ttl    = 120
 
   filter {
     type   = "geodistance"
@@ -52,7 +52,7 @@ resource "gcore_dns_zone_record" "subdomain_examplezone" {
       latlong    = [52.367, 4.9041]
       asn        = [12345]
       ip         = ["1.1.1.1"]
-      notes      = ["notes"]
+      notes      = "notes"
       continents = ["asia"]
       countries  = ["russia"]
       default    = true
@@ -64,7 +64,7 @@ resource "gcore_dns_zone_record" "subdomain_examplezone_mx" {
   zone   = "examplezone.com"
   domain = "subdomain.examplezone.com"
   type   = "MX"
-  ttl    = 10
+  ttl    = 120
 
   resource_record {
     content = "10 mail.my.com."
@@ -76,7 +76,7 @@ resource "gcore_dns_zone_record" "subdomain_examplezone_caa" {
   zone   = "examplezone.com"
   domain = "subdomain.examplezone.com"
   type   = "CAA"
-  ttl    = 10
+  ttl    = 120
 
   resource_record {
     content = "0 issue \"company.org; account=12345\""

--- a/gcore/resource_gcore_dns_zone_record.go
+++ b/gcore/resource_gcore_dns_zone_record.go
@@ -158,7 +158,8 @@ func resourceDNSZoneRecord() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-								names := []string{"geodns", "geodistance", "default", "first_n", "is_healthy"}
+								names := []string{"geodns", "geodistance", "default", "first_n", "is_healthy",
+									"healthcheck", "weighted_shuffle", "asn", "country", "continent", "region", "ip"}
 								name := i.(string)
 								for _, n := range names {
 									if n == name {


### PR DESCRIPTION
- fix https://github.com/G-Core/terraform-provider-gcore/issues/89
- fix example for free plan

tested locally

terra.tf
```
terraform {
  required_providers {
    gcore = {
            source = "local.gcore.com/repo/gcore"
             version = ">=0.3.64"
     }
  }
}
provider gcore {
  permanent_api_token = "10090$xxx"
}

resource "gcore_dns_zone_record" "xyz_bar" {
    domain = "xyz.bar"
    #id     = jsonencode(
    #    {
    #        Domain = "xyz.bar"
    #        Type   = "A"
    #        Zone   = "xyz.bar"
    #    }
    #)
    ttl    = 120
    type   = "A"
    zone   = "xyz.bar"

    filter {
        limit  = 0
        strict = true
        type   = "healthcheck"
    }
    filter {
        limit  = 0
        strict = false
        type   = "weighted_shuffle"
    }

    meta {
        healthchecks {
            frequency        = 300
            host             = "monitor.tld"
            http_status_code = 200
            method           = "GET"
            port             = 80
            protocol         = "HTTP"
            timeout          = 10
            tls              = false
            url              = "/monitor"
        }
    }

    resource_record {
        content = "1.2.3.4"
        enabled = true
    }
    resource_record {
        content = "4.5.6.7"
        enabled = true
    }
}
```

terraform apply output

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # gcore_dns_zone_record.xyz_bar will be created
  + resource "gcore_dns_zone_record" "xyz_bar" {
      + domain = "xyz.bar"
      + id     = (known after apply)
      + ttl    = 120
      + type   = "A"
      + zone   = "xyz.bar"

      + filter {
          + limit  = 0
          + strict = true
          + type   = "healthcheck"
        }
      + filter {
          + limit  = 0
          + strict = false
          + type   = "weighted_shuffle"
        }

      + meta {
          + geodns_link = (known after apply)

          + healthchecks {
              + frequency        = 300
              + host             = "monitor.tld"
              + http_status_code = 200
              + method           = "GET"
              + port             = 80
              + protocol         = "HTTP"
              + timeout          = 10
              + tls              = false
              + url              = "/monitor"
            }
        }

      + resource_record {
          + content = "1.2.3.4"
          + enabled = true
        }
      + resource_record {
          + content = "4.5.6.7"
          + enabled = true
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
gcore_dns_zone_record.xyz_bar: Creating...
gcore_dns_zone_record.xyz_bar: Creation complete after 7s [id={"Zone":"xyz.bar","Domain":"xyz.bar","Type":"A"}]
╷
│ Warning: Argument is deprecated
│
│   with provider["local.gcore.com/repo/gcore"],
│   on terra.tf line 10, in provider "gcore":
│   10: provider gcore {
│
│ Use permanent_api_token instead
│
│ (and 2 more similar warnings elsewhere)
╵

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```