### PR TITLE
GCLOUD2-15286 Remove routing_mode as we do not currently support it

### DIFF
--- a/docs/data-sources/k8sv2.md
+++ b/docs/data-sources/k8sv2.md
@@ -117,7 +117,6 @@ Read-Only:
 - `lb_mode` (String)
 - `mask_size` (Number)
 - `mask_size_v6` (Number)
-- `routing_mode` (String)
 - `tunnel` (String)
 
 

--- a/docs/resources/k8sv2.md
+++ b/docs/resources/k8sv2.md
@@ -159,7 +159,6 @@ Optional:
 - `lb_mode` (String) The operation mode of load balancing for remote backends. Supported values are snat, dsr, hybrid. The default value is snat.
 - `mask_size` (Number) Specifies the size allocated from pods_ip_pool CIDR to node.ipam.podCIDRs. The default value is 24.
 - `mask_size_v6` (Number) Specifies the size allocated from pods_ipv6_pool CIDR to node.ipam.podCIDRs. The default value is 120.
-- `routing_mode` (String) Enables native-routing mode or tunneling mode. The default value is tunnel.
 - `tunnel` (String) Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. The default value is geneve.
 
 

--- a/docs/resources/lblistener.md
+++ b/docs/resources/lblistener.md
@@ -80,6 +80,7 @@ resource "gcore_lblistener" "prometheus_9101" {
 
 output "prometheus_password" {
   value = random_password.prometheus_password.result
+  sensitive = true
 }
 ```
 

--- a/gcore/data_source_gcore_k8sv2.go
+++ b/gcore/data_source_gcore_k8sv2.go
@@ -172,11 +172,6 @@ func dataSourceK8sV2() *schema.Resource {
 										Description: "Is load balancer acceleration via XDP enabled or not.",
 										Computed:    true,
 									},
-									"routing_mode": {
-										Type:        schema.TypeString,
-										Description: "Is native-routing mode or tunneling mode enabled.",
-										Computed:    true,
-									},
 									"hubble_relay": {
 										Type:        schema.TypeBool,
 										Description: "Is Hubble Relay enabled or not.",
@@ -446,7 +441,6 @@ func dataSourceK8sV2Read(ctx context.Context, d *schema.ResourceData, m interfac
 				"encryption":      cluster.CNI.Cilium.Encryption,
 				"lb_mode":         cluster.CNI.Cilium.LoadBalancerMode.String(),
 				"lb_acceleration": cluster.CNI.Cilium.LoadBalancerAcceleration,
-				"routing_mode":    cluster.CNI.Cilium.RoutingMode.String(),
 				"hubble_relay":    cluster.CNI.Cilium.HubbleRelay,
 				"hubble_ui":       cluster.CNI.Cilium.HubbleUI,
 			}}

--- a/gcore/resource_gcore_k8sv2.go
+++ b/gcore/resource_gcore_k8sv2.go
@@ -246,13 +246,6 @@ func resourceK8sV2() *schema.Resource {
 										Computed:    true,
 										ForceNew:    true,
 									},
-									"routing_mode": {
-										Type:        schema.TypeString,
-										Description: "Enables native-routing mode or tunneling mode. The default value is tunnel.",
-										Optional:    true,
-										Computed:    true,
-										ForceNew:    true,
-									},
 									"hubble_relay": {
 										Type:        schema.TypeBool,
 										Description: "Enables Hubble Relay. The default value is false.",
@@ -560,7 +553,6 @@ func resourceK8sV2Create(ctx context.Context, d *schema.ResourceData, m interfac
 						Encryption:               cilium["encryption"].(bool),
 						LoadBalancerMode:         clusters.LBModeType(cilium["lb_mode"].(string)),
 						LoadBalancerAcceleration: cilium["lb_acceleration"].(bool),
-						RoutingMode:              clusters.RoutingModeType(cilium["routing_mode"].(string)),
 						HubbleRelay:              cilium["hubble_relay"].(bool),
 						HubbleUI:                 cilium["hubble_ui"].(bool),
 					}
@@ -745,7 +737,6 @@ func resourceK8sV2Read(ctx context.Context, d *schema.ResourceData, m interface{
 				"encryption":      cluster.CNI.Cilium.Encryption,
 				"lb_mode":         cluster.CNI.Cilium.LoadBalancerMode.String(),
 				"lb_acceleration": cluster.CNI.Cilium.LoadBalancerAcceleration,
-				"routing_mode":    cluster.CNI.Cilium.RoutingMode.String(),
 				"hubble_relay":    cluster.CNI.Cilium.HubbleRelay,
 				"hubble_ui":       cluster.CNI.Cilium.HubbleUI,
 			}}


### PR DESCRIPTION
**Changelog**

- Remove `routing_mode` from k8sv2 resource. We do not support it at the moment.