### PR TITLE
GCLOUD2-16682 Added metadata item support for instances

### DIFF
--- a/gcore/resource_gcore_instancev2.go
+++ b/gcore/resource_gcore_instancev2.go
@@ -474,6 +474,11 @@ func resourceInstanceV2Read(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 
+	clientV2, err := CreateClient(provider, d, InstancePoint, versionPointV2)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	clientVol, err := CreateClient(provider, d, volumesPoint, versionPointV1)
 	if err != nil {
 		return diag.FromErr(err)
@@ -602,7 +607,7 @@ func resourceInstanceV2Read(ctx context.Context, d *schema.ResourceData, m inter
 	metadata := d.Get("metadata_map").(map[string]interface{})
 	newMetadata := make(map[string]interface{}, len(metadata))
 	for k := range metadata {
-		md, err := instances.MetadataGet(client, instanceID, k).Extract()
+		md, err := instancesV2.MetadataItemGet(clientV2, instanceID, instancesV2.MetadataItemOpts{Key: k}).Extract()
 		if err != nil {
 			return diag.Errorf("cannot get metadata with key: %s. Error: %s", instanceID, err)
 		}
@@ -692,7 +697,7 @@ func resourceInstanceV2Update(ctx context.Context, d *schema.ResourceData, m int
 		omd, nmd := d.GetChange("metadata_map")
 		if len(omd.(map[string]interface{})) > 0 {
 			for k := range omd.(map[string]interface{}) {
-				err := instances.MetadataDelete(client, instanceID, k).Err
+				err := instancesV2.MetadataItemDelete(clientV2, instanceID, instancesV2.MetadataItemOpts{Key: k}).Err
 				if err != nil {
 					return diag.Errorf("cannot delete metadata key: %s. Error: %s", k, err)
 				}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/G-Core/gcore-dns-sdk-go v0.2.9
 	github.com/G-Core/gcore-storage-sdk-go v0.1.34
 	github.com/G-Core/gcorelabscdn-go v1.0.19
-	github.com/G-Core/gcorelabscloud-go v0.8.12
+	github.com/G-Core/gcorelabscloud-go v0.8.13
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/G-Core/gcorelabscdn-go v1.0.19 h1:P4qYP+cnO+0DrVftGnL1gt7En8/RYsl20zw
 github.com/G-Core/gcorelabscdn-go v1.0.19/go.mod h1:iSGXaTvZBzDHQW+rKFS918BgFVpONcyLEijwh8WsXpE=
 github.com/G-Core/gcorelabscloud-go v0.8.12 h1:qT8rrtSCXT+ol1g4zrl5JzWG+8IicHWCn7+U96tdlj4=
 github.com/G-Core/gcorelabscloud-go v0.8.12/go.mod h1:13Z1USxlxPbDFuYQyWqfNexlk4kUvOYTXbnvV/Z1lZo=
+github.com/G-Core/gcorelabscloud-go v0.8.13 h1:MpaT3owpIfbLP3EPZW+NDuxQfezN7FK6b+4VV0WILP8=
+github.com/G-Core/gcorelabscloud-go v0.8.13/go.mod h1:13Z1USxlxPbDFuYQyWqfNexlk4kUvOYTXbnvV/Z1lZo=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
Switched to v2 metadata_item get and delete for instances. Bump gcorelabscloud-go version to 0.8.13