### PR TITLE
GCLOUD2-21066 Upgrade gcorelabscloud-go SDK and fix security groups in vgpus

### DIFF
--- a/gcore/resource_gcore_file_share.go
+++ b/gcore/resource_gcore_file_share.go
@@ -119,6 +119,7 @@ func resourceFileShare() *schema.Resource {
 						"subnet_id": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							ForceNew:    true,
 							Description: "The ID of the subnet within the network. This is optional and can be used to specify a particular subnet for the file share.",
 						},
@@ -467,19 +468,12 @@ func expandFileShareCreateOpts(d *schema.ResourceData) (*file_shares.CreateOpts,
 		}
 	}
 
-	// The API expects legacy VolumeType on create; map new names to legacy values
-	var legacyVolumeType string
-	if typeName == "standard" {
-		legacyVolumeType = "default_share_type"
-	} else { // vast
-		legacyVolumeType = "vast_share_type"
-	}
 	opts := file_shares.CreateOpts{
-		Name:       name,
-		Protocol:   protocol,
-		Size:       size,
-		Tags:       tags,
-		VolumeType: legacyVolumeType,
+		Name:     name,
+		Protocol: protocol,
+		Size:     size,
+		Tags:     tags,
+		TypeName: typeName,
 	}
 
 	if typeName == "standard" {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/G-Core/gcore-storage-sdk-go v0.1.34
 	github.com/G-Core/gcore-waap-sdk-go v0.5.0
 	github.com/G-Core/gcorelabscdn-go v1.0.32
-	github.com/G-Core/gcorelabscloud-go v0.22.2
+	github.com/G-Core/gcorelabscloud-go v0.25.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/G-Core/gcorelabscdn-go v1.0.32 h1:n/WS9GaBpoFi0cUAaCnJBHOmF5qZJA5GWE4
 github.com/G-Core/gcorelabscdn-go v1.0.32/go.mod h1:iSGXaTvZBzDHQW+rKFS918BgFVpONcyLEijwh8WsXpE=
 github.com/G-Core/gcorelabscloud-go v0.22.2 h1:jp3GW0DlUOQpFn+Ok2tn39oPX5QTmai+WhuYz+77Pwg=
 github.com/G-Core/gcorelabscloud-go v0.22.2/go.mod h1:y0j2JVc+sDBZxGrTtGAR8pxolYKoyyY8CFUK/GEsqbI=
+github.com/G-Core/gcorelabscloud-go v0.25.2 h1:5Ojt0Myavo9/mthg1+8mSGmpjRoEuesGwOhwY+2APhY=
+github.com/G-Core/gcorelabscloud-go v0.25.2/go.mod h1:y0j2JVc+sDBZxGrTtGAR8pxolYKoyyY8CFUK/GEsqbI=
 github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
 github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
This PR performs the following changes:
- Upgrade `gcorelabscloud-go` to the latest version `v0.25.2`
- Removed workaround of legacy field `VolumeType` in the resource `gcore_file_share`. Also made the `subnet_id` an optional and computed field to avoid warnings.
- Fix the security group structure in `gcore_gpu_virtual_cluster`.