### PR TITLE
GCLOUD2-117980 fip reconcile

### DIFF
--- a/gcore/resource_gcore_baremetal.go
+++ b/gcore/resource_gcore_baremetal.go
@@ -823,20 +823,20 @@ func resourceBmInstanceUpdate(ctx context.Context, d *schema.ResourceData, m int
             }
         }
 
-        for fipID, wantPort := range desired {
-            if havePort, ok := current[fipID]; !ok || havePort != wantPort {
-                log.Printf("[DEBUG] Assign floating IP %s -> port %s", fipID, wantPort)
-                if _, err := floatingips.Assign(fipClient, fipID, floatingips.CreateOpts{PortID: wantPort}).Extract(); err != nil {
-                    return diag.Errorf("failed to assign floating IP %s to port %s: %v", fipID, wantPort, err)
-                }
-            }
-        }
-
         for fipID, havePort := range current {
             if _, ok := desired[fipID]; !ok && havePort != "" {
                 log.Printf("[DEBUG] Unassign floating IP %s (not in desired)", fipID)
                 if _, err := floatingips.UnAssign(fipClient, fipID).Extract(); err != nil {
                     return diag.Errorf("failed to unassign floating IP %s: %v", fipID, err)
+                }
+            }
+        }
+
+        for fipID, wantPort := range desired {
+            if havePort, ok := current[fipID]; !ok || havePort != wantPort {
+                log.Printf("[DEBUG] Assign floating IP %s -> port %s", fipID, wantPort)
+                if _, err := floatingips.Assign(fipClient, fipID, floatingips.CreateOpts{PortID: wantPort}).Extract(); err != nil {
+                    return diag.Errorf("failed to assign floating IP %s to port %s: %v", fipID, wantPort, err)
                 }
             }
         }

--- a/gcore/resource_gcore_baremetal.go
+++ b/gcore/resource_gcore_baremetal.go
@@ -777,23 +777,67 @@ func resourceBmInstanceUpdate(ctx context.Context, d *schema.ResourceData, m int
 			}
 		}
 
-		for _, fip := range fips {
-			log.Printf("[DEBUG] Reassign floatin IP %s to fixed IP %s port id %s", fip.FloatingIPAddress, fip.FixedIPAddress, fip.PortID)
-			mm := make(map[string]string)
-			for _, i := range fip.Metadata {
-				mm[i.Key] = i.Value
-			}
+        currentIfs, err := instances.ListInterfacesAll(client, d.Id())
+        if err != nil {
+            return diag.FromErr(err)
+        }
 
-			_, err := floatingips.Assign(fipClient, fip.ID, floatingips.CreateOpts{
-				PortID:         fip.PortID,
-				FixedIPAddress: fip.FixedIPAddress,
-				Metadata:       mm,
-			}).Extract()
+        desired := map[string]string{} // fipID -> portID
+        ifsCfg := d.Get("interface").([]interface{})
+        for _, raw := range ifsCfg {
+            iface := raw.(map[string]interface{})
+            fipID, _ := iface["existing_fip_id"].(string)
+            if fipID == "" {
+                continue
+            }
+            var portID string
+            switch types.InterfaceType(iface["type"].(string)) {
+            case types.ReservedFixedIpType:
+                portID = iface["port_id"].(string)
+            case types.SubnetInterfaceType:
+                for _, ci := range currentIfs {
+                    if ci.SubnetID == iface["subnet_id"].(string) {
+                        portID = ci.PortID
+                        break
+                    }
+                }
+            case types.AnySubnetInterfaceType:
+                for _, ci := range currentIfs {
+                    if ci.NetworkID == iface["network_id"].(string) {
+                        portID = ci.PortID
+                        break
+                    }
+                }
+            }
+            if portID != "" {
+                desired[fipID] = portID
+            }
+        }
 
-			if err != nil {
-				return diag.Errorf("cannot reassign floating IP %s to fixed IP %s port id %s. Error: %v", fip.FloatingIPAddress, fip.FixedIPAddress, fip.PortID, err)
-			}
-		}
+        current := map[string]string{}
+        for _, ci := range currentIfs {
+            for _, f := range ci.FloatingIPDetails {
+                current[f.ID] = ci.PortID
+            }
+        }
+
+        for fipID, wantPort := range desired {
+            if havePort, ok := current[fipID]; !ok || havePort != wantPort {
+                log.Printf("[DEBUG] Assign floating IP %s -> port %s", fipID, wantPort)
+                if _, err := floatingips.Assign(fipClient, fipID, floatingips.CreateOpts{PortID: wantPort}).Extract(); err != nil {
+                    return diag.Errorf("failed to assign floating IP %s to port %s: %v", fipID, wantPort, err)
+                }
+            }
+        }
+
+        for fipID, havePort := range current {
+            if _, ok := desired[fipID]; !ok && havePort != "" {
+                log.Printf("[DEBUG] Unassign floating IP %s (not in desired)", fipID)
+                if err := floatingips.Unassign(fipClient, fipID).ExtractErr(); err != nil {
+                    return diag.Errorf("failed to unassign floating IP %s: %v", fipID, err)
+                }
+            }
+        }
 	}
 
 	d.Set("last_updated", time.Now().Format(time.RFC850))

--- a/gcore/resource_gcore_baremetal.go
+++ b/gcore/resource_gcore_baremetal.go
@@ -835,7 +835,7 @@ func resourceBmInstanceUpdate(ctx context.Context, d *schema.ResourceData, m int
         for fipID, havePort := range current {
             if _, ok := desired[fipID]; !ok && havePort != "" {
                 log.Printf("[DEBUG] Unassign floating IP %s (not in desired)", fipID)
-                if err := floatingips.UnAssign(fipClient, fipID).Extract(); err != nil {
+                if _, err := floatingips.UnAssign(fipClient, fipID).Extract(); err != nil {
                     return diag.Errorf("failed to unassign floating IP %s: %v", fipID, err)
                 }
             }

--- a/gcore/resource_gcore_baremetal.go
+++ b/gcore/resource_gcore_baremetal.go
@@ -835,7 +835,8 @@ func resourceBmInstanceUpdate(ctx context.Context, d *schema.ResourceData, m int
         for fipID, havePort := range current {
             if _, ok := desired[fipID]; !ok && havePort != "" {
                 log.Printf("[DEBUG] Unassign floating IP %s (not in desired)", fipID)
-                if err := floatingips.UnAssign(fipClient, fipID).ExtractErr(); err != nil {
+                _, err := floatingips.UnAssign(client, d.Id()).Extract()
+                if err != nil {
                     return diag.Errorf("failed to unassign floating IP %s: %v", fipID, err)
                 }
             }

--- a/gcore/resource_gcore_baremetal.go
+++ b/gcore/resource_gcore_baremetal.go
@@ -835,8 +835,7 @@ func resourceBmInstanceUpdate(ctx context.Context, d *schema.ResourceData, m int
         for fipID, havePort := range current {
             if _, ok := desired[fipID]; !ok && havePort != "" {
                 log.Printf("[DEBUG] Unassign floating IP %s (not in desired)", fipID)
-                _, err := floatingips.UnAssign(client, d.Id()).Extract()
-                if err != nil {
+                if err := floatingips.UnAssign(fipClient, fipID).Extract(); err != nil {
                     return diag.Errorf("failed to unassign floating IP %s: %v", fipID, err)
                 }
             }


### PR DESCRIPTION
fixes floating IP reconciliation for baremetal interfaces by comparing desired vs current state, ensuring fips are only reassigned when needed, unassigned when absent in config and preventing redundant rebinds on apply