### PR TITLE
GCLOUD2-21572 Fix keypair creation when providing project_name

### DIFF
--- a/gcore/resource_gcore_keypair.go
+++ b/gcore/resource_gcore_keypair.go
@@ -75,7 +75,7 @@ func resourceKeypairCreate(ctx context.Context, d *schema.ResourceData, m interf
 	opts := keypairs.CreateOpts{
 		Name:      d.Get("sshkey_name").(string),
 		PublicKey: d.Get("public_key").(string),
-		ProjectID: d.Get("project_id").(int),
+		ProjectID: client.ProjectID,
 	}
 
 	kp, err := keypairs.Create(client, opts).Extract()


### PR DESCRIPTION
This PR fixes an error that occurs during keypair creation using the **gcore_keypair** resource when the user provides the `project_name` instead of the `project_id`. 