### PR TITLE
GCLOUD2-22168 Fill interface port_id and network_id in gcore_ai_cluster output

### DIFF
--- a/docs/data-sources/ai_cluster.md
+++ b/docs/data-sources/ai_cluster.md
@@ -52,6 +52,7 @@ output "view" {
 
 ### Read-Only
 
+- `attached_interfaces` (List of Object) List of attached interfaces to all instances of the cluster. (see [below for nested schema](#nestedatt--attached_interfaces))
 - `cluster_metadata` (Map of String) Cluster metadata (simple key-value pairs)
 - `cluster_name` (String) AI Cluster Name
 - `cluster_status` (String) AI Cluster status
@@ -71,6 +72,18 @@ output "view" {
 - `user_data` (String) String in base64 format. Must not be passed together with 'username' or 'password'. Examples of the user_data: https://cloudinit.readthedocs.io/en/latest/topics/examples.html
 - `username` (String) A name of a new user in the Linux instance. It may be passed with a 'password' parameter
 - `volume` (Set of Object) List of volumes attached to the cluster (see [below for nested schema](#nestedatt--volume))
+
+<a id="nestedatt--attached_interfaces"></a>
+### Nested Schema for `attached_interfaces`
+
+Read-Only:
+
+- `ip_address` (String)
+- `network_id` (String)
+- `port_id` (String)
+- `subnet_id` (String)
+- `type` (String)
+
 
 <a id="nestedatt--interface"></a>
 ### Nested Schema for `interface`

--- a/docs/resources/ai_cluster.md
+++ b/docs/resources/ai_cluster.md
@@ -180,6 +180,7 @@ resource "gcore_ai_cluster" "gpu_cluster" {
 
 ### Read-Only
 
+- `attached_interfaces` (List of Object) List of attached interfaces to all instances of the cluster. (see [below for nested schema](#nestedatt--attached_interfaces))
 - `created_at` (String) Datetime when the GPU cluster was created
 - `creator_task_id` (String) Task that created this entity
 - `id` (String) The ID of this resource.
@@ -193,16 +194,13 @@ resource "gcore_ai_cluster" "gpu_cluster" {
 
 Required:
 
-- `type` (String) Network type
+- `type` (String) Network type only available values are 'external' and 'subnet'
 
 Optional:
 
-- `network_id` (String) Network ID
-- `subnet_id` (String) Network ID the subnet belongs to. Port will be plugged in this network
-
-Read-Only:
-
-- `port_id` (String) Port is assigned to IP address from the subnet
+- `network_id` (String) Network ID the interface belongs to. Required for external type.
+- `port_id` (String, Deprecated) Port is assigned to IP address from the subnet
+- `subnet_id` (String) Subnet ID the subnet belongs to. Port will be plugged in this subnet. Required for subnet type.
 
 
 <a id="nestedblock--security_group"></a>
@@ -249,6 +247,18 @@ Read-Only:
 - `server_id` (String) Instance ID
 - `volume_id` (String) Volume ID
 
+
+
+<a id="nestedatt--attached_interfaces"></a>
+### Nested Schema for `attached_interfaces`
+
+Read-Only:
+
+- `ip_address` (String)
+- `network_id` (String)
+- `port_id` (String)
+- `subnet_id` (String)
+- `type` (String)
 
 
 <a id="nestedatt--poplar_servers"></a>


### PR DESCRIPTION
This PR fixes a bug in the `gcore_ai_cluster` resource and data source that was not filling in the `port_id` and `network_id` of the `interface` list. 

To address this problem, the following changes were made:
- Deprecate the existing `port_id` field inside the **interface** attribute, given that it wasn't being used for creating the two types of allowed interfaces (`external` and `subnet`). Furthermore, it wasn't possible to assign more than one `port_id` for a subnet, which was the case when `instance_count > 1`.
- Add a new read-only attribute **attached_interfaces** that lists all the interfaces attached to instances of the cluster. Now, users will be able to see the `port_id` of any attached interface.

In this PR, another problem was also fixed, which is related to the listing of IB network interfaces that were not being excluded from the **interface** list. This type of interface is not managed by the user, therefore, it should be excluded when showing user-managed interfaces. 

