### PR TITLE
Update resource documentation

### DIFF
--- a/docs/resources/cdn_origingroup.md
+++ b/docs/resources/cdn_origingroup.md
@@ -97,5 +97,5 @@ Required:
 
 Optional:
 
-- `backup` (Boolean) true — The option is active. The origin will not be used until one of active origins become unavailable. false — The option is disabled.
-- `enabled` (Boolean) The setting allows to enable or disable an Origin source in the Origins group
+- `backup` (Boolean) Defines whether the origin is a backup, meaning that it will not be used until one of active origins become unavailable. Default value is false.
+- `enabled` (Boolean) The setting allows to enable or disable an Origin source in the Origins group. Default value is true.

--- a/docs/resources/dns_zone_record.md
+++ b/docs/resources/dns_zone_record.md
@@ -133,16 +133,16 @@ resource "gcore_dns_zone_record" "examplezone_failover" {
   // failover/healthchecks is on rrset meta, not resource record meta
   meta {
     failover {
-      frequency = 300
-      host = "failover.examplezone.com"
+      frequency        = 300
+      host             = "failover.examplezone.com"
       http_status_code = 200
-      method = "GET"
-      port = 80
-      protocol = "HTTP"
-      regexp = ""
-      timeout = 10
-      tls = false
-      url = "/"
+      method           = "GET"
+      port             = 80
+      protocol         = "HTTP"
+      regexp           = ""
+      timeout          = 10
+      tls              = false
+      url              = "/"
     }
   }
 }
@@ -221,10 +221,9 @@ Optional:
 - `cidr_mapping` (String) Cidr mapping rule name of DNS Zone RRSet resource.
 - `failover` (Block Set) Failover meta (eg. {"frequency": 60,"host": "www.gcore.com","http_status_code": null,"method": "GET","port": 80,"protocol": "HTTP","regexp": "","timeout": 10,"tls": false,"url": "/"}). (see [below for nested schema](#nestedblock--meta--failover))
 - `geodns_link` (String) Geodns link (domain, or cl-) of DNS Zone RRSet resource.
-- `healthchecks` (Block Set) **Deprecated:** Use 'failover' instead. This field is deprecated and will be removed in a future version. (see [below for nested schema](#nestedblock--meta--healthchecks))
+- `healthchecks` (Block Set, Deprecated) Failover meta (eg. {"frequency": 60,"host": "www.gcore.com","http_status_code": null,"method": "GET","port": 80,"protocol": "HTTP","regexp": "","timeout": 10,"tls": false,"url": "/"}). (see [below for nested schema](#nestedblock--meta--healthchecks))
 
 <a id="nestedblock--meta--failover"></a>
-
 ### Nested Schema for `meta.failover`
 
 Required:
@@ -244,11 +243,9 @@ Optional:
 - `tls` (Boolean) TLS/HTTPS enabled if protocol=HTTP, must be empty for non-HTTP.
 - `url` (String) URL path to check required if protocol=HTTP, must be empty for non-HTTP.
 
+
 <a id="nestedblock--meta--healthchecks"></a>
-
 ### Nested Schema for `meta.healthchecks`
-
-**Deprecated:** Use 'failover' instead. This field is deprecated and will be removed in a future version.
 
 Required:
 
@@ -266,6 +263,8 @@ Optional:
 - `regexp` (String) HTTP body or response payload to check if protocol<>ICMP, must be empty for ICMP.
 - `tls` (Boolean) TLS/HTTPS enabled if protocol=HTTP, must be empty for non-HTTP.
 - `url` (String) URL path to check required if protocol=HTTP, must be empty for non-HTTP.
+
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/inference_deployment.md
+++ b/docs/resources/inference_deployment.md
@@ -40,6 +40,7 @@ resource "gcore_inference_deployment" "inf" {
   flavor_name = "inference-4vcpu-16gib"
   containers {
     region_id  = data.gcore_region.region.id
+    cooldown_period = 30
     scale_min = 2
     scale_max = 2
     triggers_cpu_threshold = 80

--- a/docs/resources/router.md
+++ b/docs/resources/router.md
@@ -255,7 +255,6 @@ output "router_id" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `last_updated` (String) The timestamp of the last update.
 
 <a id="nestedblock--external_gateway_info"></a>
 ### Nested Schema for `external_gateway_info`

--- a/docs/resources/storage_sftp.md
+++ b/docs/resources/storage_sftp.md
@@ -29,7 +29,7 @@ resource "gcore_storage_sftp" "example_sftp" {
 
 ### Required
 
-- `location` (String) A location of new storage resource. One of (ams, sin, fra, mia)
+- `location` (String) A location of new storage resource.
 - `name` (String) A name of new storage resource.
 
 ### Optional


### PR DESCRIPTION
## Summary
- Improve `cdn_origingroup` backup/enabled field descriptions with default values
- Fix `dns_zone_record` formatting and healthchecks deprecation notice style
- Add `cooldown_period` to `inference_deployment` example
- Remove obsolete `last_updated` attribute from `router` docs
- Remove hardcoded location list from `storage_sftp` docs

**Note:** changes generated following the execution of `make doc-generate`