### PR TITLE
ICM-47063: Fix nil pointer dereference in filterSecurityGroupRules

### DIFF
--- a/gcore/resource_gcore_k8sv2.go
+++ b/gcore/resource_gcore_k8sv2.go
@@ -928,7 +928,7 @@ func getSuitableSecurityGroup(sgs []securitygroups.SecurityGroup, name string, p
 func filterSecurityGroupRules(rules []securitygroups.SecurityGroupRule) []securitygroups.SecurityGroupRule {
 	newRules := []securitygroups.SecurityGroupRule{}
 	for _, rule := range rules {
-		if *rule.Description == "system" {
+		if rule.Description != nil && *rule.Description == "system" {
 			continue
 		}
 		newRules = append(newRules, rule)

--- a/gcore/resource_gcore_k8sv2_unit_test.go
+++ b/gcore/resource_gcore_k8sv2_unit_test.go
@@ -1,0 +1,62 @@
+package gcore
+
+import (
+	"testing"
+
+	"github.com/G-Core/gcorelabscloud-go/gcore/securitygroup/v1/securitygroups"
+	"github.com/G-Core/gcorelabscloud-go/gcore/securitygroup/v1/types"
+)
+
+func strPtr(s string) *string { return &s }
+
+// TestFilterSecurityGroupRules_NilDescription verifies that
+// filterSecurityGroupRules does not panic when a rule has a nil Description.
+//
+// Reproduces ICM-47063: the provider crashes during terraform plan/destroy
+// when the k8s cluster's worker security group contains a rule where the API
+// returns "description": null.
+func TestFilterSecurityGroupRules_NilDescription(t *testing.T) {
+	rules := []securitygroups.SecurityGroupRule{
+		{ID: "user-rule", Direction: types.RuleDirectionIngress, Description: strPtr("allow-http")},
+		{ID: "nil-desc", Direction: types.RuleDirectionEgress, Description: nil},
+		{ID: "system-rule", Direction: types.RuleDirectionIngress, Description: strPtr("system")},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("filterSecurityGroupRules panicked on nil Description: %v", r)
+		}
+	}()
+
+	result := filterSecurityGroupRules(rules)
+
+	if len(result) != 2 {
+		t.Errorf("expected 2 rules (system filtered, nil kept), got %d", len(result))
+	}
+}
+
+// TestFilterSecurityGroupRules_FiltersSystemRules verifies that rules
+// with description "system" are filtered out.
+func TestFilterSecurityGroupRules_FiltersSystemRules(t *testing.T) {
+	rules := []securitygroups.SecurityGroupRule{
+		{ID: "user-rule", Direction: types.RuleDirectionIngress, Description: strPtr("allow-http")},
+		{ID: "system-rule", Direction: types.RuleDirectionIngress, Description: strPtr("system")},
+	}
+
+	result := filterSecurityGroupRules(rules)
+
+	if len(result) != 1 {
+		t.Errorf("expected 1 rule (system filtered out), got %d", len(result))
+	}
+	if result[0].ID != "user-rule" {
+		t.Errorf("expected remaining rule to be 'user-rule', got %q", result[0].ID)
+	}
+}
+
+// TestFilterSecurityGroupRules_EmptySlice verifies no panic on empty input.
+func TestFilterSecurityGroupRules_EmptySlice(t *testing.T) {
+	result := filterSecurityGroupRules([]securitygroups.SecurityGroupRule{})
+	if len(result) != 0 {
+		t.Errorf("expected 0 rules, got %d", len(result))
+	}
+}

--- a/gcore/resource_gcore_k8sv2_unit_test.go
+++ b/gcore/resource_gcore_k8sv2_unit_test.go
@@ -22,16 +22,21 @@ func TestFilterSecurityGroupRules_NilDescription(t *testing.T) {
 		{ID: "system-rule", Direction: types.RuleDirectionIngress, Description: strPtr("system")},
 	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("filterSecurityGroupRules panicked on nil Description: %v", r)
-		}
-	}()
-
 	result := filterSecurityGroupRules(rules)
 
-	if len(result) != 2 {
-		t.Errorf("expected 2 rules (system filtered, nil kept), got %d", len(result))
+	resultIDs := make(map[string]bool, len(result))
+	for _, rule := range result {
+		resultIDs[rule.ID] = true
+	}
+
+	if !resultIDs["user-rule"] {
+		t.Errorf("expected result to contain %q", "user-rule")
+	}
+	if !resultIDs["nil-desc"] {
+		t.Errorf("expected result to contain %q", "nil-desc")
+	}
+	if resultIDs["system-rule"] {
+		t.Errorf("expected result to exclude %q", "system-rule")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix crash in `filterSecurityGroupRules` when a k8s cluster's worker security group
  contains a rule with `"description": null` from the API
- Add unit tests for `filterSecurityGroupRules`
- Fix pre-existing `%s`/`%d` format verb mismatch in `resource_gcore_cdn_origin_shielding.go`

## Problem

During `terraform plan` or `terraform destroy`, the provider panics with:

```
panic: runtime error: invalid memory address or nil pointer dereference
  filterSecurityGroupRules(...)  resource_gcore_k8sv2.go:931
  resourceK8sV2Read(...)         resource_gcore_k8sv2.go:1103
```

`filterSecurityGroupRules` dereferences `*rule.Description` without a nil check.
When the Gcore API returns a security group rule with `"description": null`
(e.g., rules created via API without a description field), the provider crashes.

This also blocks `terraform destroy` since it reads state first, leaving users completely stuck.

## Fix

Add a nil guard before dereferencing:

```go
// Before:
if *rule.Description == "system" {

// After:
if rule.Description != nil && *rule.Description == "system" {
```

## Jira

[ICM-47063](https://jira.gcore.lu/browse/ICM-47063)