### PR TITLE
Fix format verb mismatch in resourceCDNOriginShieldingRead

### DIFF
--- a/gcore/resource_gcore_cdn_origin_shielding.go
+++ b/gcore/resource_gcore_cdn_origin_shielding.go
@@ -54,7 +54,7 @@ func resourceCDNOriginShieldingRead(ctx context.Context, d *schema.ResourceData,
 			return diag.Diagnostics{
 				{
 					Severity: diag.Warning,
-					Summary:  fmt.Sprintf("Origin Shielding with id %s not found, removing from state", resourceID),
+					Summary:  fmt.Sprintf("Origin Shielding with id %d not found, removing from state", resourceID),
 				},
 			}
 		}


### PR DESCRIPTION
## Summary

- Fix `fmt.Sprintf` format verb: `%s` → `%d` for `resourceID` which is `int`

This is a pre-existing bug that causes `go vet` to fail for the entire `gcore` package,
blocking compilation of any unit tests.