### PR TITLE
ICM-47051: Fix k8sv2 pool taints and labels not being cleared on update

### DIFF
--- a/gcore/resource_gcore_k8sv2.go
+++ b/gcore/resource_gcore_k8sv2.go
@@ -1622,14 +1622,14 @@ func resourceK8sV2UpdateClusterPool(client *gcorecloud.ServiceClient, clusterNam
 	if v, ok := pool["auto_healing_enabled"].(bool); ok {
 		opts.AutoHealingEnabled = &v
 	}
-	if labels, ok := pool["labels"].(map[string]interface{}); ok && len(labels) > 0 {
+	if labels, ok := pool["labels"].(map[string]interface{}); ok {
 		result := map[string]string{}
 		for k, v := range labels {
 			result[k] = v.(string)
 		}
 		opts.Labels = &result
 	}
-	if taints, ok := pool["taints"].(map[string]interface{}); ok && len(taints) > 0 {
+	if taints, ok := pool["taints"].(map[string]interface{}); ok {
 		result := map[string]string{}
 		for k, v := range taints {
 			result[k] = v.(string)


### PR DESCRIPTION
## Summary

- Fix `resourceK8sV2UpdateClusterPool` silently skipping taint/label clearing when the user removes all taints or labels from a pool
- The `len > 0` guard on lines 1625 and 1632 caused the PATCH request to omit empty taints/labels, so the API never received a clearing payload
- Removing the guard sends `"taints": {}` / `"labels": {}` in the request body, which the API correctly interprets as a clear operation

**Jira:** [ICM-47051](https://jira.gcore.lu/browse/ICM-47051)

## Test plan

- [x] Verified API handles `"taints": {}` and `"labels": {}` as clear operations (live test)
- [x] Created cluster with 2 pools (one with taints+labels), set `taints = {}` and `labels = {}`, confirmed `tf plan` detects diff and `tf apply` clears them on the backend
- [x] Confirmed subsequent `tf plan` shows "No changes" (idempotent)
- [x] `go build ./...` passes