### PR TITLE
CDI-1355: Remove deprecated request_limiter option from CDN resources

### DIFF
--- a/docs/resources/cdn_originshielding.md
+++ b/docs/resources/cdn_originshielding.md
@@ -42,11 +42,6 @@ resource "gcore_cdn_resource" "cdn_example_com" {
     redirect_http_to_https {
       value = true
     }
-    request_limiter {
-      rate_unit = "r/s"
-      rate = 5
-      burst = 1
-    }
     gzip_on {
       value = true
     }

--- a/docs/resources/cdn_resource.md
+++ b/docs/resources/cdn_resource.md
@@ -56,11 +56,6 @@ resource "gcore_cdn_resource" "cdn_example_com" {
     redirect_http_to_https {
       value = true
     }
-    request_limiter {
-      rate_unit = "r/s"
-      rate = 5
-      burst = 1
-    }
     gzip_on {
       value = true
     }
@@ -150,7 +145,6 @@ Optional:
 - `redirect_http_to_https` (Block List, Max: 1) When enabled, HTTP requests are redirected to HTTPS. (see [below for nested schema](#nestedblock--options--redirect_http_to_https))
 - `redirect_https_to_http` (Block List, Max: 1) When enabled, HTTPS requests are redirected to HTTP. (see [below for nested schema](#nestedblock--options--redirect_https_to_http))
 - `referrer_acl` (Block List, Max: 1) Referrer access policy option allows to control access to the CDN Resource content for specified domain names. (see [below for nested schema](#nestedblock--options--referrer_acl))
-- `request_limiter` (Block List, Max: 1) It allows to limit the amount of HTTP requests (see [below for nested schema](#nestedblock--options--request_limiter))
 - `response_headers_hiding_policy` (Block List, Max: 1) Define HTTP headers (specified at an origin server) that a CDN server hides from the response. (see [below for nested schema](#nestedblock--options--response_headers_hiding_policy))
 - `rewrite` (Block List, Max: 1) Rewrite option changes and redirects the requests from the CDN to the origin. It operates according to the Nginx configuration. (see [below for nested schema](#nestedblock--options--rewrite))
 - `secure_key` (Block List, Max: 1) The option allows configuring an access with tokenized URLs. It makes impossible to access content without a valid (unexpired) hash key. When enabled, you need to specify a key that you use to generate a token. (see [below for nested schema](#nestedblock--options--secure_key))
@@ -595,21 +589,6 @@ Required:
 Optional:
 
 - `enabled` (Boolean)
-
-
-<a id="nestedblock--options--request_limiter"></a>
-### Nested Schema for `options.request_limiter`
-
-Required:
-
-- `burst` (Number)
-- `rate` (Number)
-
-Optional:
-
-- `delay` (Number)
-- `enabled` (Boolean)
-- `rate_unit` (String)
 
 
 <a id="nestedblock--options--response_headers_hiding_policy"></a>

--- a/docs/resources/cdn_rule.md
+++ b/docs/resources/cdn_rule.md
@@ -34,11 +34,6 @@ resource "gcore_cdn_rule" "cdn_example_com_rule_1" {
     redirect_http_to_https {
       value = true
     }
-    request_limiter {
-      rate_unit = "r/s"
-      rate = 5
-      burst = 1
-    }
     gzip_on {
       value = true
     }
@@ -184,7 +179,6 @@ Optional:
 - `redirect_http_to_https` (Block List, Max: 1) When enabled, HTTP requests are redirected to HTTPS. (see [below for nested schema](#nestedblock--options--redirect_http_to_https))
 - `redirect_https_to_http` (Block List, Max: 1) When enabled, HTTPS requests are redirected to HTTP. (see [below for nested schema](#nestedblock--options--redirect_https_to_http))
 - `referrer_acl` (Block List, Max: 1) Referrer access policy option allows to control access to the CDN Resource content for specified domain names. (see [below for nested schema](#nestedblock--options--referrer_acl))
-- `request_limiter` (Block List, Max: 1) It allows to limit the amount of HTTP requests (see [below for nested schema](#nestedblock--options--request_limiter))
 - `response_headers_hiding_policy` (Block List, Max: 1) Define HTTP headers (specified at an origin server) that a CDN server hides from the response. (see [below for nested schema](#nestedblock--options--response_headers_hiding_policy))
 - `rewrite` (Block List, Max: 1) Rewrite option changes and redirects the requests from the CDN to the origin. It operates according to the Nginx configuration. (see [below for nested schema](#nestedblock--options--rewrite))
 - `secure_key` (Block List, Max: 1) The option allows configuring an access with tokenized URLs. It makes impossible to access content without a valid (unexpired) hash key. When enabled, you need to specify a key that you use to generate a token. (see [below for nested schema](#nestedblock--options--secure_key))
@@ -613,21 +607,6 @@ Required:
 Optional:
 
 - `enabled` (Boolean)
-
-
-<a id="nestedblock--options--request_limiter"></a>
-### Nested Schema for `options.request_limiter`
-
-Required:
-
-- `burst` (Number)
-- `rate` (Number)
-
-Optional:
-
-- `delay` (Number)
-- `enabled` (Boolean)
-- `rate_unit` (String)
 
 
 <a id="nestedblock--options--response_headers_hiding_policy"></a>

--- a/docs/resources/cdn_rule_template.md
+++ b/docs/resources/cdn_rule_template.md
@@ -91,7 +91,6 @@ Optional:
 - `redirect_http_to_https` (Block List, Max: 1) When enabled, HTTP requests are redirected to HTTPS. (see [below for nested schema](#nestedblock--options--redirect_http_to_https))
 - `redirect_https_to_http` (Block List, Max: 1) When enabled, HTTPS requests are redirected to HTTP. (see [below for nested schema](#nestedblock--options--redirect_https_to_http))
 - `referrer_acl` (Block List, Max: 1) Referrer access policy option allows to control access to the CDN Resource content for specified domain names. (see [below for nested schema](#nestedblock--options--referrer_acl))
-- `request_limiter` (Block List, Max: 1) It allows to limit the amount of HTTP requests (see [below for nested schema](#nestedblock--options--request_limiter))
 - `response_headers_hiding_policy` (Block List, Max: 1) Define HTTP headers (specified at an origin server) that a CDN server hides from the response. (see [below for nested schema](#nestedblock--options--response_headers_hiding_policy))
 - `rewrite` (Block List, Max: 1) Rewrite option changes and redirects the requests from the CDN to the origin. It operates according to the Nginx configuration. (see [below for nested schema](#nestedblock--options--rewrite))
 - `secure_key` (Block List, Max: 1) The option allows configuring an access with tokenized URLs. It makes impossible to access content without a valid (unexpired) hash key. When enabled, you need to specify a key that you use to generate a token. (see [below for nested schema](#nestedblock--options--secure_key))
@@ -520,21 +519,6 @@ Required:
 Optional:
 
 - `enabled` (Boolean)
-
-
-<a id="nestedblock--options--request_limiter"></a>
-### Nested Schema for `options.request_limiter`
-
-Required:
-
-- `burst` (Number)
-- `rate` (Number)
-
-Optional:
-
-- `delay` (Number)
-- `enabled` (Boolean)
-- `rate_unit` (String)
 
 
 <a id="nestedblock--options--response_headers_hiding_policy"></a>

--- a/examples/resources/gcore_cdn_originshielding/resource.tf
+++ b/examples/resources/gcore_cdn_originshielding/resource.tf
@@ -27,11 +27,6 @@ resource "gcore_cdn_resource" "cdn_example_com" {
     redirect_http_to_https {
       value = true
     }
-    request_limiter {
-      rate_unit = "r/s"
-      rate = 5
-      burst = 1
-    }
     gzip_on {
       value = true
     }

--- a/examples/resources/gcore_cdn_resource/example_2.tf
+++ b/examples/resources/gcore_cdn_resource/example_2.tf
@@ -160,12 +160,6 @@ resource "gcore_cdn_resource" "cdn_example_com" {
         "*.google.com"
       ]
     }
-    request_limiter {
-      rate = 5
-      burst = 1
-      rate_unit = "r/s"
-      delay = 0
-    }
     response_headers_hiding_policy {
       mode = "hide"
       excepted = [

--- a/examples/resources/gcore_cdn_resource/resource.tf
+++ b/examples/resources/gcore_cdn_resource/resource.tf
@@ -41,11 +41,6 @@ resource "gcore_cdn_resource" "cdn_example_com" {
     redirect_http_to_https {
       value = true
     }
-    request_limiter {
-      rate_unit = "r/s"
-      rate = 5
-      burst = 1
-    }
     gzip_on {
       value = true
     }

--- a/examples/resources/gcore_cdn_rule/example_2.tf
+++ b/examples/resources/gcore_cdn_rule/example_2.tf
@@ -164,12 +164,6 @@ resource "gcore_cdn_rule" "cdn_example_com_rule_1" {
         "*.google.com"
       ]
     }
-    request_limiter {
-      rate = 5
-      burst = 1
-      rate_unit = "r/s"
-      delay = 0
-    }
     response_headers_hiding_policy {
       mode = "hide"
       excepted = [

--- a/examples/resources/gcore_cdn_rule/resource.tf
+++ b/examples/resources/gcore_cdn_rule/resource.tf
@@ -19,11 +19,6 @@ resource "gcore_cdn_rule" "cdn_example_com_rule_1" {
     redirect_http_to_https {
       value = true
     }
-    request_limiter {
-      rate_unit = "r/s"
-      rate = 5
-      burst = 1
-    }
     gzip_on {
       value = true
     }

--- a/gcore/resource_gcore_cdn_options.go
+++ b/gcore/resource_gcore_cdn_options.go
@@ -722,39 +722,6 @@ var (
 				},
 			},
 		},
-		"request_limiter": {
-			Type:        schema.TypeList,
-			MaxItems:    1,
-			Optional:    true,
-			Description: "It allows to limit the amount of HTTP requests",
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"enabled": {
-						Type:     schema.TypeBool,
-						Optional: true,
-						Default:  true,
-					},
-					"rate": {
-						Type:     schema.TypeInt,
-						Required: true,
-					},
-					"burst": {
-						Type:     schema.TypeInt,
-						Required: true,
-					},
-					"rate_unit": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Default:  "r/s",
-					},
-					"delay": {
-						Type:     schema.TypeInt,
-						Optional: true,
-						Default:  0,
-					},
-				},
-			},
-		},
 		"response_headers_hiding_policy": {
 			Type:        schema.TypeList,
 			MaxItems:    1,

--- a/gcore/resource_gcore_cdn_resource.go
+++ b/gcore/resource_gcore_cdn_resource.go
@@ -536,15 +536,6 @@ func listToOptions(l []interface{}) *gcdn.Options {
 			opts.ReferrerACL.ExceptedValues = append(opts.ReferrerACL.ExceptedValues, v.(string))
 		}
 	}
-	if opt, ok := getOptByName(fields, "request_limiter"); ok {
-		opts.RequestLimiter = &gcdn.RequestLimiter{
-			Enabled:  opt["enabled"].(bool),
-			Rate:     opt["rate"].(int),
-			Burst:    opt["burst"].(int),
-			RateUnit: opt["rate_unit"].(string),
-			Delay:    opt["delay"].(int),
-		}
-	}
 	if opt, ok := getOptByName(fields, "response_headers_hiding_policy"); ok {
 		opts.ResponseHeadersHidingPolicy = &gcdn.ResponseHeadersHidingPolicy{
 			Enabled: opt["enabled"].(bool),
@@ -827,10 +818,6 @@ func optionsToList(options *gcdn.Options) []interface{} {
 	if options.ReferrerACL != nil {
 		m := structToMap(options.ReferrerACL)
 		result["referrer_acl"] = []interface{}{m}
-	}
-	if options.RequestLimiter != nil {
-		m := structToMap(options.RequestLimiter)
-		result["request_limiter"] = []interface{}{m}
 	}
 	if options.ResponseHeadersHidingPolicy != nil {
 		m := structToMap(options.ResponseHeadersHidingPolicy)


### PR DESCRIPTION
## Summary
- Remove the deprecated and non-functional `request_limiter` CDN option from the Terraform provider
- Remove schema definition, Terraform-to-SDK and SDK-to-Terraform conversion logic
- Remove from all example configurations and regenerate documentation

> Note: skipping the standard Terraform deprecation cycle is intentional — `request_limiter` is only consumed by internal Gcore accounts, so no external users' configs will be affected.

## Test plan
- [x] `go build ./...` passes
- [x] `make vet` passes
- [x] Grep confirms zero remaining `request_limiter` references in source, examples, and docs