### PR TITLE
Update proxy_cache_key allowed values

### DIFF
--- a/docs/resources/cdn_resource.md
+++ b/docs/resources/cdn_resource.md
@@ -472,7 +472,7 @@ Optional:
 
 Required:
 
-- `value` (String) Key for caching. Should be a combination of the specified variables: $request_uri, $scheme, $uri.
+- `value` (String) Key for caching. Should be a combination of the specified variables: $http_x_cdn_real_host, $request_uri, $scheme, $uri.
 
 Optional:
 

--- a/docs/resources/cdn_rule.md
+++ b/docs/resources/cdn_rule.md
@@ -490,7 +490,7 @@ Optional:
 
 Required:
 
-- `value` (String) Key for caching. Should be a combination of the specified variables: $request_uri, $scheme, $uri.
+- `value` (String) Key for caching. Should be a combination of the specified variables: $http_x_cdn_real_host, $request_uri, $scheme, $uri.
 
 Optional:
 

--- a/docs/resources/cdn_rule_template.md
+++ b/docs/resources/cdn_rule_template.md
@@ -402,7 +402,7 @@ Optional:
 
 Required:
 
-- `value` (String) Key for caching. Should be a combination of the specified variables: $request_uri, $scheme, $uri.
+- `value` (String) Key for caching. Should be a combination of the specified variables: $http_x_cdn_real_host, $request_uri, $scheme, $uri.
 
 Optional:
 

--- a/gcore/resource_gcore_cdn_options.go
+++ b/gcore/resource_gcore_cdn_options.go
@@ -513,7 +513,7 @@ var (
 					"value": {
 						Type:        schema.TypeString,
 						Required:    true,
-						Description: "Key for caching. Should be a combination of the specified variables: $request_uri, $scheme, $uri.",
+						Description: "Key for caching. Should be a combination of the specified variables: $http_x_cdn_real_host, $request_uri, $scheme, $uri.",
 					},
 				},
 			},


### PR DESCRIPTION
Update the proxy_cache_key.value description (and generated docs) to include $http_x_cdn_real_host alongside $request_uri, $scheme, and $uri.