### PR TITLE
test(cloud_instance_image): add acceptance test + sweeper (GCLOUD2-24277)

### DIFF
--- a/internal/services/cloud_instance_image/resource_test.go
+++ b/internal/services/cloud_instance_image/resource_test.go
@@ -1,0 +1,127 @@
+package cloud_instance_image_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/G-Core/gcore-go/cloud"
+	"github.com/G-Core/gcore-go/packages/param"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/G-Core/terraform-provider-gcore/internal/acctest"
+)
+
+// testImageURL is a small, publicly-accessible Linux cloud image used for acceptance tests.
+// Using a known-good minimal image to keep upload times short.
+const testImageURL = "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2003.qcow2.xz"
+
+func TestAccCloudInstanceImage_basic(t *testing.T) {
+	rName := acctest.RandomName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudInstanceImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudInstanceImageConfig(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("gcore_cloud_instance_image.test",
+						tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+					statecheck.ExpectKnownValue("gcore_cloud_instance_image.test",
+						tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue("gcore_cloud_instance_image.test",
+						tfjsonpath.New("status"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue("gcore_cloud_instance_image.test",
+						tfjsonpath.New("visibility"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCloudInstanceImage_import(t *testing.T) {
+	rName := acctest.RandomName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudInstanceImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudInstanceImageConfig(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("gcore_cloud_instance_image.test",
+						tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+				},
+			},
+			{
+				ResourceName:      "gcore_cloud_instance_image.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// url, hw_firmware_type, tags, and cow_format are create-only inputs
+				// not returned by the API on read.
+				ImportStateVerifyIgnore: []string{"url", "hw_firmware_type", "tags", "cow_format"},
+				ImportStateIdFunc: acctest.BuildImportID(
+					"gcore_cloud_instance_image.test",
+					"project_id", "region_id", "id",
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudInstanceImageDestroy(s *terraform.State) error {
+	client, err := acctest.NewGcoreClient()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gcore_cloud_instance_image" {
+			continue
+		}
+
+		projectID, err := strconv.ParseInt(rs.Primary.Attributes["project_id"], 10, 64)
+		if err != nil {
+			return fmt.Errorf("error parsing project_id: %w", err)
+		}
+		regionID, err := strconv.ParseInt(rs.Primary.Attributes["region_id"], 10, 64)
+		if err != nil {
+			return fmt.Errorf("error parsing region_id: %w", err)
+		}
+
+		_, err = client.Cloud.Instances.Images.Get(
+			context.Background(),
+			rs.Primary.ID,
+			cloud.InstanceImageGetParams{
+				ProjectID: param.NewOpt(projectID),
+				RegionID:  param.NewOpt(regionID),
+			},
+		)
+
+		if err == nil {
+			return fmt.Errorf("instance image %s still exists", rs.Primary.ID)
+		}
+		if !acctest.IsNotFoundError(err) {
+			return fmt.Errorf("error checking instance image deletion: %w", err)
+		}
+	}
+	return nil
+}
+
+func testAccCloudInstanceImageConfig(name string) string {
+	return fmt.Sprintf(`
+resource "gcore_cloud_instance_image" "test" {
+  project_id = %[1]s
+  region_id  = %[2]s
+  name       = %[3]q
+  url        = %[4]q
+}`, acctest.ProjectID(), acctest.RegionID(), name, testImageURL)
+}

--- a/internal/services/cloud_instance_image/sweep.go
+++ b/internal/services/cloud_instance_image/sweep.go
@@ -1,0 +1,79 @@
+package cloud_instance_image
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/G-Core/gcore-go"
+	"github.com/G-Core/gcore-go/cloud"
+	"github.com/G-Core/gcore-go/option"
+	"github.com/G-Core/gcore-go/packages/param"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/G-Core/terraform-provider-gcore/internal/sweep"
+)
+
+func init() {
+	resource.AddTestSweepers("gcore_cloud_instance_image", &resource.Sweeper{
+		Name: "gcore_cloud_instance_image",
+		F:    sweepCloudInstanceImages,
+	})
+}
+
+func sweepCloudInstanceImages(_ string) error {
+	if err := sweep.ValidateSweeperEnvironment(); err != nil {
+		return err
+	}
+
+	apiKey := os.Getenv("GCORE_API_KEY")
+	projectID, err := strconv.ParseInt(os.Getenv("GCORE_CLOUD_PROJECT_ID"), 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse GCORE_CLOUD_PROJECT_ID: %w", err)
+	}
+	regionID, err := strconv.ParseInt(os.Getenv("GCORE_CLOUD_REGION_ID"), 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse GCORE_CLOUD_REGION_ID: %w", err)
+	}
+
+	client := gcore.NewClient(
+		option.WithAPIKey(apiKey),
+		option.WithCloudProjectID(projectID),
+	)
+
+	ctx := context.Background()
+
+	page, err := client.Cloud.Instances.Images.List(ctx, cloud.InstanceImageListParams{
+		ProjectID: param.NewOpt(projectID),
+		RegionID:  param.NewOpt(regionID),
+	})
+	if err != nil {
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping instance image sweep: %s", err)
+			return nil
+		}
+		return fmt.Errorf("error listing instance images: %w", err)
+	}
+
+	for _, image := range page.Results {
+		name := image.Name
+		id := image.ID
+
+		if !sweep.ShouldSweep("gcore_cloud_instance_image", name) {
+			continue
+		}
+
+		log.Printf("[INFO] Deleting instance image: %s (%s)", name, id)
+		err := client.Cloud.Instances.Images.DeleteAndPoll(ctx, id, cloud.InstanceImageDeleteParams{
+			ProjectID: param.NewOpt(projectID),
+			RegionID:  param.NewOpt(regionID),
+		})
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete instance image %s: %s", name, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/G-Core/terraform-provider-gcore/internal/services/cdn_certificate"
 
 	// Cloud
+	_ "github.com/G-Core/terraform-provider-gcore/internal/services/cloud_instance_image"
 	_ "github.com/G-Core/terraform-provider-gcore/internal/services/cloud_placement_group"
 	_ "github.com/G-Core/terraform-provider-gcore/internal/services/cloud_ssh_key"
 


### PR DESCRIPTION
## What
Adds acceptance test coverage for the `gcore_cloud_instance_image` resource (GCLOUD2-24277).

- **`TestAccCloudInstanceImage_basic`** — uploads an image from a URL, asserts `name`, `id`, `status`, `visibility`.
- **`TestAccCloudInstanceImage_import`** — import-state verify (ignoring create-only fields `url`, `hw_firmware_type`, `tags`, `cow_format`).
- **`CheckDestroy`** — verifies deletion via `Cloud.Instances.Images.Get`.
- **Sweeper** `sweepCloudInstanceImages` (lists + `DeleteAndPoll`), registered in `internal/sweep/sweep_test.go`.

## Approach
Mirrors the existing `cloud_gpu_baremetal_cluster_image` image acctest (same upload-from-URL pattern, same shared `internal/acctest` / `internal/sweep` helpers and `testImageURL`).

## Verification
- `go vet ./internal/services/cloud_instance_image/... ./internal/sweep/...` → clean (exit 0).
- `gofmt` clean.
- Acceptance tests require `TF_ACC=1` + `GCORE_API_KEY` / `GCORE_CLOUD_PROJECT_ID` / `GCORE_CLOUD_REGION_ID`; not run here (no live creds in this environment).

Not merging — for review.