### PR TITLE
Fix gcore_cdn_origingroup failing on computed origin source

### DIFF
--- a/gcore/resource_gcore_cdn_origin_group.go
+++ b/gcore/resource_gcore_cdn_origin_group.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/G-Core/gcorelabscdn-go/origingroups"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -212,6 +213,11 @@ func validateCDNOriginGroupConfig(ctx context.Context, diff *schema.ResourceDiff
 	}
 
 	if originExists {
+		// CustomizeDiff runs at plan time, where attributes sourced from other resources'
+		// computed ("known after apply") values are not yet known. The legacy diff surface
+		// collapses such values to their zero value, so required-field checks must consult
+		// the raw config to tell "the user left it empty" apart from "not yet known".
+		rawConfig := diff.GetRawConfig()
 		originList := diff.Get("origin").([]interface{})
 		for i, originRaw := range originList {
 			if originRaw == nil {
@@ -225,7 +231,7 @@ func validateCDNOriginGroupConfig(ctx context.Context, diff *schema.ResourceDiff
 
 			if originType == "host" {
 				source, _ := origin["source"].(string)
-				if source == "" {
+				if source == "" && !originAttrIsUnknown(rawConfig, i, "source") {
 					return fmt.Errorf("origin.%d: `source` is required for host origins", i)
 				}
 
@@ -251,7 +257,7 @@ func validateCDNOriginGroupConfig(ctx context.Context, diff *schema.ResourceDiff
 					return fmt.Errorf("origin.%d: `config` must be an object for s3 origins", i)
 				}
 
-				if err := validateS3ConfigFields(i, cfg); err != nil {
+				if err := validateS3ConfigFields(rawConfig, i, cfg); err != nil {
 					return err
 				}
 			}
@@ -261,22 +267,108 @@ func validateCDNOriginGroupConfig(ctx context.Context, diff *schema.ResourceDiff
 	return nil
 }
 
-func validateS3ConfigFields(index int, cfg map[string]interface{}) error {
+func validateS3ConfigFields(rawConfig cty.Value, index int, cfg map[string]interface{}) error {
 	s3Type, _ := cfg["s3_type"].(string)
 
 	if s3Type == "other" {
-		if val, ok := cfg["s3_storage_hostname"].(string); !ok || val == "" {
+		if val, _ := cfg["s3_storage_hostname"].(string); val == "" && !originConfigAttrIsUnknown(rawConfig, index, "s3_storage_hostname") {
 			return fmt.Errorf("origin.%d.config: `s3_storage_hostname` is required when `s3_type` is 'other'", index)
 		}
 	}
 
 	if s3Type == "amazon" {
-		if val, ok := cfg["s3_region"].(string); !ok || val == "" {
+		if val, _ := cfg["s3_region"].(string); val == "" && !originConfigAttrIsUnknown(rawConfig, index, "s3_region") {
 			return fmt.Errorf("origin.%d.config: `s3_region` is required when `s3_type` is 'amazon'", index)
 		}
 	}
 
 	return nil
+}
+
+// lookupRawOrigin locates origin[index] within the raw configuration. ok is false when the
+// value cannot be resolved (for example under the legacy unit-test diff path that does not
+// populate the raw config), in which case callers should validate normally. unknown is true
+// when the origin (or the whole origin list) is a "known after apply" value.
+func lookupRawOrigin(rawConfig cty.Value, index int) (origin cty.Value, ok, unknown bool) {
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
+		return cty.NilVal, false, false
+	}
+	t := rawConfig.Type()
+	if !t.IsObjectType() || !t.HasAttribute("origin") {
+		return cty.NilVal, false, false
+	}
+	origins := rawConfig.GetAttr("origin")
+	if origins.IsNull() {
+		return cty.NilVal, false, false
+	}
+	if !origins.IsKnown() {
+		return cty.NilVal, false, true
+	}
+	if !origins.CanIterateElements() {
+		return cty.NilVal, false, false
+	}
+	elements := origins.AsValueSlice()
+	if index < 0 || index >= len(elements) {
+		return cty.NilVal, false, false
+	}
+	origin = elements[index]
+	if origin.IsNull() {
+		return cty.NilVal, false, false
+	}
+	if !origin.IsKnown() {
+		return cty.NilVal, false, true
+	}
+	return origin, true, false
+}
+
+// originAttrIsUnknown reports whether the named attribute of origin[index] in the raw
+// configuration is a computed ("known after apply") value.
+func originAttrIsUnknown(rawConfig cty.Value, index int, attr string) bool {
+	origin, ok, unknown := lookupRawOrigin(rawConfig, index)
+	if unknown {
+		return true
+	}
+	if !ok || !origin.Type().HasAttribute(attr) {
+		return false
+	}
+	return !origin.GetAttr(attr).IsKnown()
+}
+
+// originConfigAttrIsUnknown reports whether the named attribute of the nested
+// origin[index].config block is a computed ("known after apply") value.
+func originConfigAttrIsUnknown(rawConfig cty.Value, index int, attr string) bool {
+	origin, ok, unknown := lookupRawOrigin(rawConfig, index)
+	if unknown {
+		return true
+	}
+	if !ok || !origin.Type().HasAttribute("config") {
+		return false
+	}
+	config := origin.GetAttr("config")
+	if config.IsNull() {
+		return false
+	}
+	if !config.IsKnown() {
+		return true
+	}
+	if !config.CanIterateElements() {
+		return false
+	}
+	elements := config.AsValueSlice()
+	if len(elements) == 0 {
+		return false
+	}
+	cfg := elements[0]
+	if cfg.IsNull() {
+		return false
+	}
+	if !cfg.IsKnown() {
+		return true
+	}
+	if !cfg.Type().IsObjectType() || !cfg.Type().HasAttribute(attr) {
+		return false
+	}
+	return !cfg.GetAttr(attr).IsKnown()
 }
 
 func resourceCDNOriginGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/gcore/resource_gcore_cdn_origin_group.go
+++ b/gcore/resource_gcore_cdn_origin_group.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/G-Core/gcorelabscdn-go/origingroups"
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -213,11 +212,6 @@ func validateCDNOriginGroupConfig(ctx context.Context, diff *schema.ResourceDiff
 	}
 
 	if originExists {
-		// CustomizeDiff runs at plan time, where attributes sourced from other resources'
-		// computed ("known after apply") values are not yet known. The legacy diff surface
-		// collapses such values to their zero value, so required-field checks must consult
-		// the raw config to tell "the user left it empty" apart from "not yet known".
-		rawConfig := diff.GetRawConfig()
 		originList := diff.Get("origin").([]interface{})
 		for i, originRaw := range originList {
 			if originRaw == nil {
@@ -230,8 +224,10 @@ func validateCDNOriginGroupConfig(ctx context.Context, diff *schema.ResourceDiff
 			}
 
 			if originType == "host" {
+				// Skip the check when source is "known after apply" (sourced from another
+				// resource's computed attribute), which the diff collapses to an empty string.
 				source, _ := origin["source"].(string)
-				if source == "" && !originAttrIsUnknown(rawConfig, i, "source") {
+				if source == "" && diff.NewValueKnown(fmt.Sprintf("origin.%d.source", i)) {
 					return fmt.Errorf("origin.%d: `source` is required for host origins", i)
 				}
 
@@ -257,7 +253,7 @@ func validateCDNOriginGroupConfig(ctx context.Context, diff *schema.ResourceDiff
 					return fmt.Errorf("origin.%d: `config` must be an object for s3 origins", i)
 				}
 
-				if err := validateS3ConfigFields(rawConfig, i, cfg); err != nil {
+				if err := validateS3ConfigFields(diff, i, cfg); err != nil {
 					return err
 				}
 			}
@@ -267,108 +263,26 @@ func validateCDNOriginGroupConfig(ctx context.Context, diff *schema.ResourceDiff
 	return nil
 }
 
-func validateS3ConfigFields(rawConfig cty.Value, index int, cfg map[string]interface{}) error {
+// validateS3ConfigFields checks required S3 config fields, skipping any field that is
+// "known after apply" (NewValueKnown), which the diff collapses to an empty string.
+func validateS3ConfigFields(diff *schema.ResourceDiff, index int, cfg map[string]interface{}) error {
 	s3Type, _ := cfg["s3_type"].(string)
 
 	if s3Type == "other" {
-		if val, _ := cfg["s3_storage_hostname"].(string); val == "" && !originConfigAttrIsUnknown(rawConfig, index, "s3_storage_hostname") {
+		val, _ := cfg["s3_storage_hostname"].(string)
+		if val == "" && diff.NewValueKnown(fmt.Sprintf("origin.%d.config.0.s3_storage_hostname", index)) {
 			return fmt.Errorf("origin.%d.config: `s3_storage_hostname` is required when `s3_type` is 'other'", index)
 		}
 	}
 
 	if s3Type == "amazon" {
-		if val, _ := cfg["s3_region"].(string); val == "" && !originConfigAttrIsUnknown(rawConfig, index, "s3_region") {
+		val, _ := cfg["s3_region"].(string)
+		if val == "" && diff.NewValueKnown(fmt.Sprintf("origin.%d.config.0.s3_region", index)) {
 			return fmt.Errorf("origin.%d.config: `s3_region` is required when `s3_type` is 'amazon'", index)
 		}
 	}
 
 	return nil
-}
-
-// lookupRawOrigin locates origin[index] within the raw configuration. ok is false when the
-// value cannot be resolved (for example under the legacy unit-test diff path that does not
-// populate the raw config), in which case callers should validate normally. unknown is true
-// when the origin (or the whole origin list) is a "known after apply" value.
-func lookupRawOrigin(rawConfig cty.Value, index int) (origin cty.Value, ok, unknown bool) {
-	if rawConfig.IsNull() || !rawConfig.IsKnown() {
-		return cty.NilVal, false, false
-	}
-	t := rawConfig.Type()
-	if !t.IsObjectType() || !t.HasAttribute("origin") {
-		return cty.NilVal, false, false
-	}
-	origins := rawConfig.GetAttr("origin")
-	if origins.IsNull() {
-		return cty.NilVal, false, false
-	}
-	if !origins.IsKnown() {
-		return cty.NilVal, false, true
-	}
-	if !origins.CanIterateElements() {
-		return cty.NilVal, false, false
-	}
-	elements := origins.AsValueSlice()
-	if index < 0 || index >= len(elements) {
-		return cty.NilVal, false, false
-	}
-	origin = elements[index]
-	if origin.IsNull() {
-		return cty.NilVal, false, false
-	}
-	if !origin.IsKnown() {
-		return cty.NilVal, false, true
-	}
-	return origin, true, false
-}
-
-// originAttrIsUnknown reports whether the named attribute of origin[index] in the raw
-// configuration is a computed ("known after apply") value.
-func originAttrIsUnknown(rawConfig cty.Value, index int, attr string) bool {
-	origin, ok, unknown := lookupRawOrigin(rawConfig, index)
-	if unknown {
-		return true
-	}
-	if !ok || !origin.Type().HasAttribute(attr) {
-		return false
-	}
-	return !origin.GetAttr(attr).IsKnown()
-}
-
-// originConfigAttrIsUnknown reports whether the named attribute of the nested
-// origin[index].config block is a computed ("known after apply") value.
-func originConfigAttrIsUnknown(rawConfig cty.Value, index int, attr string) bool {
-	origin, ok, unknown := lookupRawOrigin(rawConfig, index)
-	if unknown {
-		return true
-	}
-	if !ok || !origin.Type().HasAttribute("config") {
-		return false
-	}
-	config := origin.GetAttr("config")
-	if config.IsNull() {
-		return false
-	}
-	if !config.IsKnown() {
-		return true
-	}
-	if !config.CanIterateElements() {
-		return false
-	}
-	elements := config.AsValueSlice()
-	if len(elements) == 0 {
-		return false
-	}
-	cfg := elements[0]
-	if cfg.IsNull() {
-		return false
-	}
-	if !cfg.IsKnown() {
-		return true
-	}
-	if !cfg.Type().IsObjectType() || !cfg.Type().HasAttribute(attr) {
-		return false
-	}
-	return !cfg.GetAttr(attr).IsKnown()
 }
 
 func resourceCDNOriginGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/gcore/resource_gcore_cdn_origin_group_test.go
+++ b/gcore/resource_gcore_cdn_origin_group_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/G-Core/gcorelabscdn-go/origingroups"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -383,6 +384,130 @@ func TestValidateCDNOriginGroupConfig(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+// TestValidateCDNOriginGroupConfigComputedSource guards against the regression in
+// https://github.com/G-Core/terraform-provider-gcore/issues/319: a host origin whose
+// `source` is sourced from another resource's computed ("known after apply") value must
+// not fail validation at plan time. The unknown value is detected via the raw config,
+// which the legacy diff surface collapses to an empty string.
+func TestValidateCDNOriginGroupConfigComputedSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawConfig cty.Value
+		index     int
+		attr      string
+		want      bool
+	}{
+		{
+			name: "host source known after apply",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{
+				"origin": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"source":      cty.UnknownVal(cty.String),
+						"origin_type": cty.StringVal("host"),
+					}),
+				}),
+			}),
+			index: 0,
+			attr:  "source",
+			want:  true,
+		},
+		{
+			name: "host source is a known literal",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{
+				"origin": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"source":      cty.StringVal("example.com"),
+						"origin_type": cty.StringVal("host"),
+					}),
+				}),
+			}),
+			index: 0,
+			attr:  "source",
+			want:  false,
+		},
+		{
+			name: "whole origin list known after apply",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{
+				"origin": cty.UnknownVal(cty.List(cty.Object(map[string]cty.Type{
+					"source": cty.String,
+				}))),
+			}),
+			index: 0,
+			attr:  "source",
+			want:  true,
+		},
+		{
+			name:      "nil raw config falls back to normal validation",
+			rawConfig: cty.NilVal,
+			index:     0,
+			attr:      "source",
+			want:      false,
+		},
+		{
+			name: "index out of range",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{
+				"origin": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"source": cty.UnknownVal(cty.String),
+					}),
+				}),
+			}),
+			index: 5,
+			attr:  "source",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := originAttrIsUnknown(tt.rawConfig, tt.index, tt.attr); got != tt.want {
+				t.Fatalf("originAttrIsUnknown() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateCDNOriginGroupConfigComputedS3ConfigField verifies that S3 config fields
+// (s3_region, s3_storage_hostname) sourced from computed values are detected as unknown
+// so their "required" checks are skipped, matching the host `source` behaviour.
+func TestValidateCDNOriginGroupConfigComputedS3ConfigField(t *testing.T) {
+	rawConfig := cty.ObjectVal(map[string]cty.Value{
+		"origin": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"origin_type": cty.StringVal("s3"),
+				"config": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"s3_type":   cty.StringVal("amazon"),
+						"s3_region": cty.UnknownVal(cty.String),
+					}),
+				}),
+			}),
+		}),
+	})
+
+	if !originConfigAttrIsUnknown(rawConfig, 0, "s3_region") {
+		t.Fatal("expected computed s3_region to be reported as unknown")
+	}
+	if originConfigAttrIsUnknown(rawConfig, 0, "s3_type") {
+		t.Fatal("expected known s3_type not to be reported as unknown")
+	}
+
+	// validateS3ConfigFields must not error when the required region is computed: the
+	// legacy diff surface presents it as an empty string.
+	cfg := map[string]interface{}{
+		"s3_type":   "amazon",
+		"s3_region": "",
+	}
+	if err := validateS3ConfigFields(rawConfig, 0, cfg); err != nil {
+		t.Fatalf("unexpected error for computed s3_region: %v", err)
+	}
+
+	// With a nil raw config (the legacy unit-test diff path) the required check still fires.
+	if err := validateS3ConfigFields(cty.NilVal, 0, cfg); err == nil {
+		t.Fatal("expected error for missing s3_region when raw config is unavailable")
 	}
 }
 

--- a/gcore/resource_gcore_cdn_origin_group_test.go
+++ b/gcore/resource_gcore_cdn_origin_group_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/G-Core/gcorelabscdn-go/origingroups"
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -387,127 +386,106 @@ func TestValidateCDNOriginGroupConfig(t *testing.T) {
 	}
 }
 
-// TestValidateCDNOriginGroupConfigComputedSource guards against the regression in
-// https://github.com/G-Core/terraform-provider-gcore/issues/319: a host origin whose
-// `source` is sourced from another resource's computed ("known after apply") value must
-// not fail validation at plan time. The unknown value is detected via the raw config,
-// which the legacy diff surface collapses to an empty string.
-func TestValidateCDNOriginGroupConfigComputedSource(t *testing.T) {
+// unknownVariableValue mirrors the SDK's hcl2shim.UnknownVariableValue sentinel (which
+// lives in an internal package). Setting an attribute to this value makes the diff treat it
+// as a computed ("known after apply") value, as if it referenced another resource.
+const unknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
+
+// TestValidateCDNOriginGroupConfigComputed verifies that a required attribute which is
+// "known after apply" does not fail validation at plan time. The cases drive the real
+// Resource.Diff path, where the diff collapses such a value to an empty string but
+// NewValueKnown still reports it as unknown.
+func TestValidateCDNOriginGroupConfigComputed(t *testing.T) {
 	tests := []struct {
-		name      string
-		rawConfig cty.Value
-		index     int
-		attr      string
-		want      bool
+		name    string
+		config  map[string]interface{}
+		wantErr string
 	}{
 		{
-			name: "host source known after apply",
-			rawConfig: cty.ObjectVal(map[string]cty.Value{
-				"origin": cty.ListVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"source":      cty.UnknownVal(cty.String),
-						"origin_type": cty.StringVal("host"),
-					}),
-				}),
-			}),
-			index: 0,
-			attr:  "source",
-			want:  true,
+			name: "computed host source does not error",
+			config: map[string]interface{}{
+				"name": "terraform_acctest_group",
+				"origin": []interface{}{
+					map[string]interface{}{
+						"origin_type": "host",
+						"source":      unknownVariableValue,
+					},
+				},
+			},
 		},
 		{
-			name: "host source is a known literal",
-			rawConfig: cty.ObjectVal(map[string]cty.Value{
-				"origin": cty.ListVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"source":      cty.StringVal("example.com"),
-						"origin_type": cty.StringVal("host"),
-					}),
-				}),
-			}),
-			index: 0,
-			attr:  "source",
-			want:  false,
+			name: "empty host source still errors",
+			config: map[string]interface{}{
+				"name": "terraform_acctest_group",
+				"origin": []interface{}{
+					map[string]interface{}{
+						"origin_type": "host",
+						"source":      "",
+					},
+				},
+			},
+			wantErr: "origin.0: `source` is required for host origins",
 		},
 		{
-			name: "whole origin list known after apply",
-			rawConfig: cty.ObjectVal(map[string]cty.Value{
-				"origin": cty.UnknownVal(cty.List(cty.Object(map[string]cty.Type{
-					"source": cty.String,
-				}))),
-			}),
-			index: 0,
-			attr:  "source",
-			want:  true,
+			name: "computed amazon s3_region does not error",
+			config: map[string]interface{}{
+				"name": "terraform_acctest_group",
+				"origin": []interface{}{
+					map[string]interface{}{
+						"origin_type": "s3",
+						"config": []interface{}{
+							map[string]interface{}{
+								"s3_type":              "amazon",
+								"s3_bucket_name":       "bucket",
+								"s3_access_key_id":     "dummy-access-key",
+								"s3_secret_access_key": "dummy-secret-key",
+								"s3_region":            unknownVariableValue,
+							},
+						},
+					},
+				},
+			},
 		},
 		{
-			name:      "nil raw config falls back to normal validation",
-			rawConfig: cty.NilVal,
-			index:     0,
-			attr:      "source",
-			want:      false,
-		},
-		{
-			name: "index out of range",
-			rawConfig: cty.ObjectVal(map[string]cty.Value{
-				"origin": cty.ListVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"source": cty.UnknownVal(cty.String),
-					}),
-				}),
-			}),
-			index: 5,
-			attr:  "source",
-			want:  false,
+			name: "computed other s3_storage_hostname does not error",
+			config: map[string]interface{}{
+				"name": "terraform_acctest_group",
+				"origin": []interface{}{
+					map[string]interface{}{
+						"origin_type": "s3",
+						"config": []interface{}{
+							map[string]interface{}{
+								"s3_type":              "other",
+								"s3_bucket_name":       "bucket",
+								"s3_access_key_id":     "dummy-access-key",
+								"s3_secret_access_key": "dummy-secret-key",
+								"s3_storage_hostname":  unknownVariableValue,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
+
+	originGroupResource := resourceCDNOriginGroup()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := originAttrIsUnknown(tt.rawConfig, tt.index, tt.attr); got != tt.want {
-				t.Fatalf("originAttrIsUnknown() = %v, want %v", got, tt.want)
+			_, err := originGroupResource.Diff(context.Background(), nil, terraform.NewResourceConfigRaw(tt.config), nil)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
-	}
-}
-
-// TestValidateCDNOriginGroupConfigComputedS3ConfigField verifies that S3 config fields
-// (s3_region, s3_storage_hostname) sourced from computed values are detected as unknown
-// so their "required" checks are skipped, matching the host `source` behaviour.
-func TestValidateCDNOriginGroupConfigComputedS3ConfigField(t *testing.T) {
-	rawConfig := cty.ObjectVal(map[string]cty.Value{
-		"origin": cty.ListVal([]cty.Value{
-			cty.ObjectVal(map[string]cty.Value{
-				"origin_type": cty.StringVal("s3"),
-				"config": cty.ListVal([]cty.Value{
-					cty.ObjectVal(map[string]cty.Value{
-						"s3_type":   cty.StringVal("amazon"),
-						"s3_region": cty.UnknownVal(cty.String),
-					}),
-				}),
-			}),
-		}),
-	})
-
-	if !originConfigAttrIsUnknown(rawConfig, 0, "s3_region") {
-		t.Fatal("expected computed s3_region to be reported as unknown")
-	}
-	if originConfigAttrIsUnknown(rawConfig, 0, "s3_type") {
-		t.Fatal("expected known s3_type not to be reported as unknown")
-	}
-
-	// validateS3ConfigFields must not error when the required region is computed: the
-	// legacy diff surface presents it as an empty string.
-	cfg := map[string]interface{}{
-		"s3_type":   "amazon",
-		"s3_region": "",
-	}
-	if err := validateS3ConfigFields(rawConfig, 0, cfg); err != nil {
-		t.Fatalf("unexpected error for computed s3_region: %v", err)
-	}
-
-	// With a nil raw config (the legacy unit-test diff path) the required check still fires.
-	if err := validateS3ConfigFields(cty.NilVal, 0, cfg); err == nil {
-		t.Fatal("expected error for missing s3_region when raw config is unavailable")
 	}
 }
 


### PR DESCRIPTION
Closes #319

## Problem

`gcore_cdn_origingroup` fails at plan time (since 0.33.0) when an origin field is wired to another resource's computed attribute, e.g.:

```hcl
origin {
  source = aws_s3_bucket.example.bucket_regional_domain_name
}
```

The `validateCDNOriginGroupConfig` `CustomizeDiff` hook added in 0.33.0 checks that required fields are non-empty. At plan time a "known after apply" value is collapsed to an empty string by the legacy diff surface, so the check mis-fires with errors like:

```
origin.0: `source` is required for host origins
```

The same affects S3 origins whose `s3_region` / `s3_storage_hostname` reference computed values.

## Fix

Guard the required-field checks with the SDK's `diff.NewValueKnown(...)`, which reports whether a plan-time attribute is fully known. When the value is "known after apply" the check is skipped; genuinely-empty values still error.

`NewValueKnown` reads the computed marker directly off the diff, so it works on the same code path that both production and the unit-test harness exercise. An earlier raw-config (`GetRawConfig`) approach was tried but `GetRawConfig` returns a null value on the unit-test diff path, leaving the fix unverifiable end-to-end.

## Tests

- `TestValidateCDNOriginGroupConfigComputed` drives the real `Resource.Diff` path with a "known after apply" value for host `source`, amazon `s3_region`, and other `s3_storage_hostname`, asserting validation passes — and that a genuinely-empty value still errors.
- Existing `TestValidateCDNOriginGroupConfig` cases continue to pass.
- `go build`, `gofmt`, `go vet` clean.

## Note

The deprecated top-level `auth` block has the same latent limitation but is left untouched, as it is superseded by `origin` blocks.
