### PR TITLE
Added new param types and metadata for FastEdge templates

### DIFF
--- a/docs/resources/fastedge_template.md
+++ b/docs/resources/fastedge_template.md
@@ -60,9 +60,10 @@ resource "gcore_fastedge_template" "test_template" {
 Required:
 
 - `name` (String) Parameter name.
-- `type` (String) Parameter type. Possible values are: string, number, date, time, secret.
+- `type` (String) Parameter type. Possible values are: string, number, date, time, secret, store, bool, json, enum.
 
 Optional:
 
 - `descr` (String) Parameter description.
 - `mandatory` (Boolean) Is parameter mandatory, true/false (false by default).
+- `metadata` (String) Parameter metadata.

--- a/gcore/resource_gcore_fastedge_template.go
+++ b/gcore/resource_gcore_fastedge_template.go
@@ -15,7 +15,7 @@ import (
 	sdk "github.com/G-Core/FastEdge-client-sdk-go"
 )
 
-var paramTypes = []string{"string", "number", "date", "time", "secret"}
+var paramTypes = []string{"string", "number", "date", "time", "secret", "store", "bool", "json", "enum"}
 
 func resourceFastEdgeTemplate() *schema.Resource {
 	return &schema.Resource{
@@ -69,6 +69,11 @@ func resourceFastEdgeTemplate() *schema.Resource {
 						},
 						"descr": {
 							Description: "Parameter description.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
+						"metadata": {
+							Description: "Parameter metadata.",
 							Type:        schema.TypeString,
 							Optional:    true,
 						},
@@ -150,6 +155,7 @@ func resourceFastEdgeTemplateRead(ctx context.Context, d *schema.ResourceData, m
 				"type":      param.DataType,
 				"mandatory": param.Mandatory,
 				"descr":     param.Descr,
+				"metadata":  param.Metadata,
 			}
 		}
 		d.Set("param", params)
@@ -230,18 +236,23 @@ func procParams(d *schema.ResourceData) []sdk.TemplateParam {
 		res := make([]sdk.TemplateParam, len(list))
 		for i, v := range list {
 			p := v.(map[string]any)
-			var descr *string
-			if tmp, ok := p["descr"].(string); ok {
-				descr = &tmp
-			}
 			res[i] = sdk.TemplateParam{
 				Name:      p["name"].(string),
 				DataType:  sdk.TemplateParamDataType(p["type"].(string)),
 				Mandatory: p["mandatory"].(bool),
-				Descr:     descr,
+				Descr:     getField[string](p, "descr"),
+				Metadata:  getField[string](p, "metadata"),
 			}
 		}
 		return res
 	}
 	return []sdk.TemplateParam{}
+}
+
+func getField[T comparable](p map[string]any, name string) *T {
+	var zero T
+	if v, ok := p[name].(T); ok && v != zero {
+		return &v
+	}
+	return nil
 }

--- a/gcore/resource_gcore_fastedge_template_test.go
+++ b/gcore/resource_gcore_fastedge_template_test.go
@@ -16,9 +16,16 @@ var baseTemplateJson string = `
 	"params": [
 		{
 			"name": "param1",
-			"data_type": "string",
+			"data_type": "enum",
 			"mandatory": true,
-			"descr": "param1 description"
+			"descr": "param1 description",
+			"metadata": "{\"allowed\":[\"a\",\"b\"]}"
+		},
+		{
+			"name": "param2",
+			"data_type": "bool",
+			"mandatory": false,
+			"descr": "param2 description"
 		}
 	]
 }
@@ -31,10 +38,17 @@ var baseTemplate sdk.Template = sdk.Template{
 	LongDescr:  ptr("long description"),
 	Params: []sdk.TemplateParam{
 		{
+			Name:      "param2",
+			DataType:  "bool",
+			Mandatory: false,
+			Descr:     ptr("param2 description"),
+		},
+		{
 			Name:      "param1",
-			DataType:  "string",
+			DataType:  "enum",
 			Mandatory: true,
 			Descr:     ptr("param1 description"),
+			Metadata:  ptr(`{"allowed":["a","b"]}`),
 		},
 	},
 }
@@ -44,9 +58,15 @@ var baseTfFastEdgeTemplConfig string = `resource "gcore_fastedge_template" "test
 	long_descr = "long description"
 	param {
 		name = "param1"
-		type = "string"
+		type = "enum"
 		mandatory = true
 		descr = "param1 description"
+		metadata = "{\"allowed\":[\"a\",\"b\"]}"
+	}
+	param {
+		name = "param2"
+		type = "bool"
+		descr = "param2 description"
 	}
 `
 
@@ -120,10 +140,19 @@ func TestFastEdgeTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "binary", "314"),
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "short_descr", "short description"),
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "long_descr", "long description"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.name", "param1"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.type", "string"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.mandatory", "true"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.descr", "param1 description"),
+					resource.TestCheckTypeSetElemNestedAttrs("gcore_fastedge_template.test", "param.*", map[string]string{
+						"name":      "param1",
+						"type":      "enum",
+						"mandatory": "true",
+						"descr":     "param1 description",
+						"metadata":  `{"allowed":["a","b"]}`,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("gcore_fastedge_template.test", "param.*", map[string]string{
+						"name":      "param2",
+						"type":      "bool",
+						"mandatory": "false",
+						"descr":     "param2 description",
+					}),
 				),
 			},
 			{ // update resource
@@ -136,10 +165,19 @@ func TestFastEdgeTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "binary", "314"),
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "short_descr", "short description"),
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "long_descr", "long description"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.name", "param1"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.type", "string"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.mandatory", "true"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.descr", "param1 description"),
+					resource.TestCheckTypeSetElemNestedAttrs("gcore_fastedge_template.test", "param.*", map[string]string{
+						"name":      "param1",
+						"type":      "enum",
+						"mandatory": "true",
+						"descr":     "param1 description",
+						"metadata":  `{"allowed":["a","b"]}`,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("gcore_fastedge_template.test", "param.*", map[string]string{
+						"name":      "param2",
+						"type":      "bool",
+						"mandatory": "false",
+						"descr":     "param2 description",
+					}),
 				),
 			},
 		},
@@ -212,10 +250,19 @@ func TestFastEdgeTemplate_disappear(t *testing.T) {
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "binary", "314"),
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "short_descr", "short description"),
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "long_descr", "long description"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.name", "param1"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.type", "string"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.mandatory", "true"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.descr", "param1 description"),
+					resource.TestCheckTypeSetElemNestedAttrs("gcore_fastedge_template.test", "param.*", map[string]string{
+						"name":      "param1",
+						"type":      "enum",
+						"mandatory": "true",
+						"descr":     "param1 description",
+						"metadata":  `{"allowed":["a","b"]}`,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("gcore_fastedge_template.test", "param.*", map[string]string{
+						"name":      "param2",
+						"type":      "bool",
+						"mandatory": "false",
+						"descr":     "param2 description",
+					}),
 				),
 			},
 			{ // resource disappeared - re-create
@@ -228,10 +275,19 @@ func TestFastEdgeTemplate_disappear(t *testing.T) {
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "binary", "314"),
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "short_descr", "short description"),
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "long_descr", "long description"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.name", "param1"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.type", "string"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.mandatory", "true"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.descr", "param1 description"),
+					resource.TestCheckTypeSetElemNestedAttrs("gcore_fastedge_template.test", "param.*", map[string]string{
+						"name":      "param1",
+						"type":      "enum",
+						"mandatory": "true",
+						"descr":     "param1 description",
+						"metadata":  `{"allowed":["a","b"]}`,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("gcore_fastedge_template.test", "param.*", map[string]string{
+						"name":      "param2",
+						"type":      "bool",
+						"mandatory": "false",
+						"descr":     "param2 description",
+					}),
 				),
 			},
 		},
@@ -273,10 +329,19 @@ func TestFastEdgeTemplate_import(t *testing.T) {
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "binary", "314"),
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "short_descr", "short description"),
 					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "long_descr", "long description"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.name", "param1"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.type", "string"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.mandatory", "true"),
-					resource.TestCheckResourceAttr("gcore_fastedge_template.test", "param.0.descr", "param1 description"),
+					resource.TestCheckTypeSetElemNestedAttrs("gcore_fastedge_template.test", "param.*", map[string]string{
+						"name":      "param1",
+						"type":      "enum",
+						"mandatory": "true",
+						"descr":     "param1 description",
+						"metadata":  `{"allowed":["a","b"]}`,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("gcore_fastedge_template.test", "param.*", map[string]string{
+						"name":      "param2",
+						"type":      "bool",
+						"mandatory": "false",
+						"descr":     "param2 description",
+					}),
 				),
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.3
 
 require (
 	github.com/AlekSi/pointer v1.2.0
-	github.com/G-Core/FastEdge-client-sdk-go v0.3.6
+	github.com/G-Core/FastEdge-client-sdk-go v0.4.0
 	github.com/G-Core/gcore-dns-sdk-go v0.3.3
 	github.com/G-Core/gcore-storage-sdk-go v0.1.34
 	github.com/G-Core/gcore-waap-sdk-go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/G-Core/FastEdge-client-sdk-go v0.3.6 h1:V4K3ET2Ni0m7Ldx4A75Z6+CKeaKqqD4wpQmPEt8pYWE=
 github.com/G-Core/FastEdge-client-sdk-go v0.3.6/go.mod h1:u48RHs6FiN7i7hSo0A44aRVP2kpXPLWYjn8x6+RW5t8=
+github.com/G-Core/FastEdge-client-sdk-go v0.4.0 h1:JiW4F/WbTUrYWpzLy0mFgt6oSJxntTMsvsjeGdBiZP4=
+github.com/G-Core/FastEdge-client-sdk-go v0.4.0/go.mod h1:u48RHs6FiN7i7hSo0A44aRVP2kpXPLWYjn8x6+RW5t8=
 github.com/G-Core/gcore-dns-sdk-go v0.3.3 h1:McILJSbJ5nOcT0MI0aBYhEuufCF329YbqKwFIN0RjCI=
 github.com/G-Core/gcore-dns-sdk-go v0.3.3/go.mod h1:35t795gOfzfVanhzkFyUXEzaBuMXwETmJldPpP28MN4=
 github.com/G-Core/gcore-storage-sdk-go v0.1.34 h1:0GPQfz1kA6mQi6fiisGsh0Um4H9PZeHWIPsc825cDrY=


### PR DESCRIPTION
To reflect recent changes in FastEdge API added new param types and metadata field (mostly used for `enum` type params) to FastEdge template definition.